### PR TITLE
fix enroll url parsing

### DIFF
--- a/regybox/classes.py
+++ b/regybox/classes.py
@@ -284,6 +284,9 @@ class Class:
         return responses[0]
 
 
+from functools import lru_cache
+
+@lru_cache(maxsize=None)
 def get_classes_tags(year: int, month: int, day: int) -> list[Tag]:
     """Fetch all class tags for a specific date.
 

--- a/regybox/classes.py
+++ b/regybox/classes.py
@@ -204,7 +204,7 @@ class Class:
         onclick: str = button.attrs["onclick"]
         LOGGER.debug(f"Found button onclick action: '{onclick}")
         button_urls: list[str] = [
-            part for part in onclick.split("'") if part.startswith("php/aulas/")
+            part for part in onclick.split("'") if ".php" in part
         ]
         if len(button_urls) != 1:
             raise UnparseableError(
@@ -284,6 +284,24 @@ class Class:
         return responses[0]
 
 
+def get_classes_tags(year: int, month: int, day: int) -> list[Tag]:
+    """Fetch all class tags for a specific date.
+
+    Args:
+        year: The year of the date.
+        month: The month of the date.
+        day: The day of the date.
+
+    Returns:
+        A list of Tag objects containing the HTML for the classes for
+        the specified date.
+    """
+    timestamp: int = int(datetime.datetime(year, month, day, tzinfo=TIMEZONE).timestamp() * 1000)
+    res_html = get_classes_html(timestamp)
+    soup: BeautifulSoup = BeautifulSoup(res_html, "html.parser")
+    return soup.find_all("div", attrs={"class": "filtro0"})
+
+
 def get_classes(year: int, month: int, day: int) -> list[Class]:
     """Fetch all classes for a specific date.
 
@@ -295,10 +313,7 @@ def get_classes(year: int, month: int, day: int) -> list[Class]:
     Returns:
         A list of Class objects representing the classes for the specified date.
     """
-    timestamp: int = int(datetime.datetime(year, month, day, tzinfo=TIMEZONE).timestamp() * 1000)
-    res_html = get_classes_html(timestamp)
-    soup: BeautifulSoup = BeautifulSoup(res_html, "html.parser")
-    return [Class(tag) for tag in soup.find_all("div", attrs={"class": "filtro0"})]
+    return [Class(tag) for tag in get_classes_tags(year, month, day)]
 
 
 def pick_class(

--- a/regybox/classes.py
+++ b/regybox/classes.py
@@ -3,6 +3,7 @@
 import datetime
 import re
 from dataclasses import dataclass, field
+from functools import cache
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
@@ -203,9 +204,7 @@ class Class:
     def _get_button_url(button: Tag) -> str:
         onclick: str = button.attrs["onclick"]
         LOGGER.debug(f"Found button onclick action: '{onclick}")
-        button_urls: list[str] = [
-            part for part in onclick.split("'") if ".php" in part
-        ]
+        button_urls: list[str] = [part for part in onclick.split("'") if ".php" in part]
         if len(button_urls) != 1:
             raise UnparseableError(
                 f"Expecting one url in button, found {len(button_urls)}: {onclick}"
@@ -284,9 +283,7 @@ class Class:
         return responses[0]
 
 
-from functools import lru_cache
-
-@lru_cache(maxsize=None)
+@cache
 def get_classes_tags(year: int, month: int, day: int) -> list[Tag]:
     """Fetch all class tags for a specific date.
 

--- a/tests/html_examples/closed_starting_soon.html
+++ b/tests/html_examples/closed_starting_soon.html
@@ -1,10 +1,8 @@
-<div class="filtro0 filtro57 profs2009" id="feed_time_slot1715185800"
- style="padding-top:10px; padding-left:5px; padding-right:5px;">
- <div class="card2 round_rect_all_5"
-  style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #D7FFE2; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
+<div class="filtro0 filtro1 profs822" id="feed_time_slot1719599400" style="padding-top:10px; padding-left:5px; padding-right:5px;">
+ <div class="card2 round_rect_all_5" style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #f7eb05; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
   <div class="row no-gap" style="width:100%">
    <div align="left" class="col-50" style="text-transform:uppercase">
-    Metcon Rato
+    WOD Rato
    </div>
    <div align="right" class="col-50" style="text-transform:uppercase">
     Rato
@@ -14,23 +12,22 @@
   </div>
   <div class="row no-gap" style="height:30px;">
    <div align="left" class="col">
-    17:30 - 18:20
+    19:30 - 20:20
    </div>
    <div align="center" class="col">
-    5 of 15
+    2 of 15
    </div>
    <div align="right" class="col">
    </div>
   </div>
   <div class="row no-gap" style="padding-bottom:10px">
    <div align="left" class="col col-auto" style="display: inline-flex; align-items: center;">
-    <a class="link icon-only"
-     onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=43303&amp;valor4=2024-05-08&amp;source=mes');">
+    <a class="link icon-only" onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=44290&amp;valor4=2024-06-28&amp;source=mes');">
      <i class="material-icons" style="font-size:30px;">
       visibility
      </i>
     </a>
-    <a class="link icon-only" onclick="popup('php/popups/regras_especiais.php','&amp;id=43303')">
+    <a class="link icon-only" onclick="popup('php/popups/regras_especiais.php','&amp;id=44290')">
      <i class="material-icons">
       error
      </i>

--- a/tests/html_examples/export.py
+++ b/tests/html_examples/export.py
@@ -1,3 +1,5 @@
+"""Export class tags to HTML files for testing purposes."""
+
 from pathlib import Path
 
 from bs4.element import Tag

--- a/tests/html_examples/export.py
+++ b/tests/html_examples/export.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from bs4.element import Tag
+
+
+def export_class_tag(tag: Tag, name: str) -> None:
+    """Export a class tag to a HTML file in html_examples.
+
+    Class tags should generally be created using the get_classes_tags
+    function.
+
+    Args:
+        tag (Tag): The tag to export.
+        name (str): The name of the HTML file to export to.
+
+    Examples:
+        >>> from regybox.classes import get_classes_tags
+        >>> from tests.html_examples.export import export_class_tag
+        >>> tags = get_classes_tags(year=2024, month=7, day=1)
+        >>> export_class_tag(tags[0], 'example_class')
+    """
+    Path(__file__).parent.joinpath(f"{name}.html").write_text(tag.prettify(), encoding="utf-8")

--- a/tests/html_examples/finished.html
+++ b/tests/html_examples/finished.html
@@ -1,7 +1,5 @@
-<div class="filtro0 filtro1 profs2009" id="feed_time_slot1715146200"
- style="padding-top:10px; padding-left:5px; padding-right:5px;">
- <div class="card2 round_rect_all_5"
-  style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #f7eb05; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
+<div class="filtro0 filtro1 profs822" id="feed_time_slot1719595800" style="padding-top:10px; padding-left:5px; padding-right:5px;">
+ <div class="card2 round_rect_all_5" style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #f7eb05; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
   <div class="row no-gap" style="width:100%">
    <div align="left" class="col-50" style="text-transform:uppercase">
     WOD Rato
@@ -14,20 +12,24 @@
   </div>
   <div class="row no-gap" style="height:30px;">
    <div align="left" class="col">
-    06:30 - 07:20
+    18:30 - 19:20
    </div>
    <div align="center" class="col">
-    11 of 15
+    13 of 15
    </div>
    <div align="right" class="col">
    </div>
   </div>
   <div class="row no-gap" style="padding-bottom:10px">
    <div align="left" class="col col-auto" style="display: inline-flex; align-items: center;">
-    <a class="link icon-only"
-     onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=43297&amp;valor4=2024-05-08&amp;source=mes');">
+    <a class="link icon-only" onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=44289&amp;valor4=2024-06-28&amp;source=mes');">
      <i class="material-icons" style="font-size:30px;">
       visibility
+     </i>
+    </a>
+    <a class="link icon-only" onclick="popup('php/popups/regras_especiais.php','&amp;id=44289')">
+     <i class="material-icons">
+      error
      </i>
     </a>
    </div>

--- a/tests/html_examples/full.html
+++ b/tests/html_examples/full.html
@@ -1,48 +1,44 @@
-<div class="filtro0 filtro1 profs2009" id="feed_time_slot1715707800"
- style="padding-top:10px; padding-left:5px; padding-right:5px;">
- <div class="card2 round_rect_all_5"
-  style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #f7eb05; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
+<div class="filtro0 filtro54 profs2133" id="feed_time_slot1719651600" style="padding-top:10px; padding-left:5px; padding-right:5px;">
+ <div class="card2 round_rect_all_5" style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #FFD7F3; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
   <div class="row no-gap" style="width:100%">
    <div align="left" class="col-50" style="text-transform:uppercase">
-    WOD Rato
+    AulÃ£o Benfica
    </div>
    <div align="right" class="col-50" style="text-transform:uppercase">
-    Rato
+    Benfica
    </div>
   </div>
   <div style="padding-top:5px;">
   </div>
   <div class="row no-gap" style="height:30px;">
    <div align="left" class="col">
-    18:30 - 19:20
+    10:00 - 11:20
    </div>
    <div align="center" class="col">
-    16 of 15
+    28 of 27
    </div>
    <div align="right" class="col">
-    <button class="col button button-small button-fill color-green buts_inscrever round_rect_all but_insc43504"
-     onclick="confirma_marca_aula('&lt;br&gt;There are specific rules for canceling this registration.&lt;br&gt;You can cancel your registration until 1 hour before the class.&lt;br&gt;Are you sure you want to register??','php/aulas/marca_aulas.php?id_aula=43504&amp;data=2024-05-14&amp;source=mes&amp;ano=2024&amp;id_rato=2120&amp;x=0000112222345667777999abbcee')">
+    <button class="col button button-small button-fill color-green buts_inscrever round_rect_all but_insc44442" onclick="confirma_marca_aula('&lt;br&gt;There are specific rules for canceling this registration.&lt;br&gt;You can cancel your registration until 1 hour before the class.&lt;br&gt;Are you sure you want to register??','../app_nova/php/aulas/marca_aulas.php?id_aula=44442&amp;data=2024-06-29&amp;source=mes&amp;ano=2024&amp;id_rato=2120&amp;x=003789aaaaaabbbbccccddeeeeef')">
      REGISTER
     </button>
    </div>
   </div>
   <div class="row no-gap" style="padding-bottom:10px">
    <div align="left" class="col col-auto" style="display: inline-flex; align-items: center;">
-    <a class="link icon-only"
-     onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=43504&amp;valor4=2024-05-14&amp;source=mes');">
+    <a class="link icon-only" onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=44442&amp;valor4=2024-06-29&amp;source=mes');">
      <i class="material-icons" style="font-size:30px;">
       visibility
      </i>
     </a>
-    <a class="link icon-only" onclick="popup('php/popups/regras_especiais.php','&amp;id=43504')">
+    <a class="link icon-only" onclick="popup('php/popups/regras_especiais.php','&amp;id=44442')">
      <i class="material-icons">
       error
      </i>
     </a>
    </div>
    <div align="right" class="col" style="padding-top:5px; line-height:16px; text-transform:uppercase">
-    <input class="timers" id="timer43504" type="hidden" value="20316" />
-    <span class="timer_class" id="feed_timer43504">
+    <input class="timers" id="timer44442" type="hidden" value="50654"/>
+    <span class="timer_class" id="feed_timer44442">
     </span>
    </div>
   </div>

--- a/tests/html_examples/not_yet_open.html
+++ b/tests/html_examples/not_yet_open.html
@@ -1,10 +1,8 @@
-<div class="filtro0 filtro29 profs2009" id="feed_time_slot1715418000"
- style="padding-top:10px; padding-left:5px; padding-right:5px;">
- <div class="card2 round_rect_all_5"
-  style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #F4D7FF; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
+<div class="filtro0 filtro1 profs822" id="feed_time_slot1719815400" style="padding-top:10px; padding-left:5px; padding-right:5px;">
+ <div class="card2 round_rect_all_5" style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #f7eb05; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
   <div class="row no-gap" style="width:100%">
    <div align="left" class="col-50" style="text-transform:uppercase">
-    Weekend WOD Rato
+    WOD Rato
    </div>
    <div align="right" class="col-50" style="text-transform:uppercase">
     Rato
@@ -14,25 +12,19 @@
   </div>
   <div class="row no-gap" style="height:30px;">
    <div align="left" class="col">
-    10:00 - 10:50
+    07:30 - 08:20
    </div>
    <div align="center" class="col">
-    0 of 16
+    1 of 15
    </div>
    <div align="right" class="col">
    </div>
   </div>
   <div class="row no-gap" style="padding-bottom:10px">
    <div align="left" class="col col-auto" style="display: inline-flex; align-items: center;">
-    <a class="link icon-only"
-     onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=43326&amp;valor4=2024-05-11&amp;source=mes');">
+    <a class="link icon-only" onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=44472&amp;valor4=2024-07-01&amp;source=mes');">
      <i class="material-icons" style="font-size:30px;">
       visibility
-     </i>
-    </a>
-    <a class="link icon-only" onclick="popup('php/popups/regras_especiais.php','&amp;id=43326')">
-     <i class="material-icons">
-      error
      </i>
     </a>
    </div>
@@ -40,9 +32,9 @@
     <span class="letra_10">
      Registrations in
     </span>
-    <br />
-    <input class="timers" id="timer43326" type="hidden" value="71253" />
-    <span class="timer_class" id="feed_timer43326">
+    <br/>
+    <input class="timers" id="timer44472" type="hidden" value="456"/>
+    <span class="timer_class" id="feed_timer44472">
     </span>
    </div>
   </div>

--- a/tests/html_examples/open.html
+++ b/tests/html_examples/open.html
@@ -1,10 +1,8 @@
-<div class="filtro0 filtro57 profs2009" id="feed_time_slot1715185800"
- style="padding-top:10px; padding-left:5px; padding-right:5px;">
- <div class="card2 round_rect_all_5"
-  style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #D7FFE2; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
+<div class="filtro0 filtro1 profs822" id="feed_time_slot1719811800" style="padding-top:10px; padding-left:5px; padding-right:5px;">
+ <div class="card2 round_rect_all_5" style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #f7eb05; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
   <div class="row no-gap" style="width:100%">
    <div align="left" class="col-50" style="text-transform:uppercase">
-    Metcon Rato
+    WOD Rato
    </div>
    <div align="right" class="col-50" style="text-transform:uppercase">
     Rato
@@ -14,35 +12,28 @@
   </div>
   <div class="row no-gap" style="height:30px;">
    <div align="left" class="col">
-    17:30 - 18:20
+    06:30 - 07:20
    </div>
    <div align="center" class="col">
-    6 of 15
+    5 of 15
    </div>
    <div align="right" class="col">
-    <button class="col button button-small button-fill color-green buts_inscrever round_rect_all but_insc43303"
-     onclick="confirma_marca_aula('&lt;br&gt;There are specific rules for canceling this registration.&lt;br&gt;You can cancel your registration until 1 hour before the class.&lt;br&gt;Are you sure you want to register??','php/aulas/marca_aulas.php?id_aula=43303&amp;data=2024-05-08&amp;source=mes&amp;ano=2024&amp;id_rato=2120&amp;x=0123346677778889bbbbcdddefff')">
+    <button class="col button button-small button-fill color-green round_rect_all buts_inscrever round_rect_all but_insc44471" onclick="javascript:load_script ('../app_nova/php/aulas/marca_aulas.php?id_aula=44471&amp;data=2024-07-01&amp;source=mes&amp;ano=2024&amp;id_rato=2120&amp;x=00113455677789aabcddddeeefff','prov'); $('.buts_inscrever').fadeOut();">
      REGISTER
     </button>
    </div>
   </div>
   <div class="row no-gap" style="padding-bottom:10px">
    <div align="left" class="col col-auto" style="display: inline-flex; align-items: center;">
-    <a class="link icon-only"
-     onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=43303&amp;valor4=2024-05-08&amp;source=mes');">
+    <a class="link icon-only" onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=44471&amp;valor4=2024-07-01&amp;source=mes');">
      <i class="material-icons" style="font-size:30px;">
       visibility
      </i>
     </a>
-    <a class="link icon-only" onclick="popup('php/popups/regras_especiais.php','&amp;id=43303')">
-     <i class="material-icons">
-      error
-     </i>
-    </a>
    </div>
    <div align="right" class="col" style="padding-top:5px; line-height:16px; text-transform:uppercase">
-    <input class="timers" id="timer43303" type="hidden" value="10133" />
-    <span class="timer_class" id="feed_timer43303">
+    <input class="timers" id="timer44471" type="hidden" value="210677"/>
+    <span class="timer_class" id="feed_timer44471">
     </span>
    </div>
   </div>

--- a/tests/html_examples/overbooked.html
+++ b/tests/html_examples/overbooked.html
@@ -1,0 +1,43 @@
+<div class="filtro0 filtro53 profs1" id="feed_time_slot1719651600" style="padding-top:10px; padding-left:5px; padding-right:5px;">
+ <div class="card2 round_rect_all_5" style="padding-top:10px; padding-bottom:0px; border-left: 2px solid #FFD7D7; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);">
+  <div class="row no-gap" style="width:100%">
+   <div align="left" class="col-50" style="text-transform:uppercase">
+    AulÃ£o Loures
+   </div>
+   <div align="right" class="col-50" style="text-transform:uppercase">
+    Loures
+   </div>
+  </div>
+  <div style="padding-top:5px;">
+  </div>
+  <div class="row no-gap" style="height:30px;">
+   <div align="left" class="col">
+    10:00 - 11:20
+   </div>
+   <div align="center" class="col">
+    40 of 36
+   </div>
+   <div align="right" class="col">
+   </div>
+  </div>
+  <div class="row no-gap" style="padding-bottom:10px">
+   <div align="left" class="col col-auto" style="display: inline-flex; align-items: center;">
+    <a class="link icon-only" onclick="javascript:popup('php/aulas/detalhes_aula.php','&amp;valor1=&amp;valor2=2024&amp;valor3=44142&amp;valor4=2024-06-29&amp;source=mes');">
+     <i class="material-icons" style="font-size:30px;">
+      visibility
+     </i>
+    </a>
+    <a class="link icon-only" onclick="popup('php/popups/regras_especiais.php','&amp;id=44142')">
+     <i class="material-icons">
+      error
+     </i>
+    </a>
+   </div>
+   <div align="right" class="col" style="padding-top:5px; line-height:16px; text-transform:uppercase">
+    <span class="erro_color">
+     Class full
+    </span>
+   </div>
+  </div>
+ </div>
+</div>

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -132,8 +132,18 @@ def test_full() -> None:
 
 
 def test_overbooked() -> None:
-    with pytest.raises(FileNotFoundError):
-        extract_class("overbooked.html")
+    class_: Class = extract_class("overbooked.html")
+    assert class_.is_open is False
+    assert class_.is_full is True
+    assert class_.is_overbooked is True
+    assert class_.is_over is False
+    assert class_.user_is_blocked is True
+    assert class_.user_is_enrolled is False
+    assert class_.user_is_waitlisted is False
+    assert class_.time_to_start is None  # timer to start disappears when class is overbooked
+    assert class_.time_to_enroll is None
+    assert class_.enroll_url is None
+    assert class_.unenroll_url is None
 
 
 def test_registered_for_other() -> None:


### PR DESCRIPTION
- fix picking out enroll url due to html changes
- update most html examples
- create helper function to export html examples
- create auxilary get_classes_tags function to return tags instead of class objects

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses the issue of enroll URL parsing by updating the HTML structure and introducing a new helper function for exporting HTML examples. Additionally, it includes an auxiliary function to fetch class tags and updates the existing HTML examples and tests accordingly.

- **New Features**:
    - Introduced a helper function to export HTML examples for class tags.
- **Bug Fixes**:
    - Fixed the parsing of enroll URLs due to changes in the HTML structure.
- **Enhancements**:
    - Updated most HTML examples to reflect the new structure.
    - Created an auxiliary function `get_classes_tags` to return tags instead of class objects.
- **Tests**:
    - Added new tests for the overbooked class scenario to ensure correct behavior.

<!-- Generated by sourcery-ai[bot]: end summary -->