### PR TITLE
remove cache for class checks

### DIFF
--- a/regybox/classes.py
+++ b/regybox/classes.py
@@ -3,7 +3,6 @@
 import datetime
 import re
 from dataclasses import dataclass, field
-from functools import cache
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
@@ -283,7 +282,6 @@ class Class:
         return responses[0]
 
 
-@cache
 def get_classes_tags(year: int, month: int, day: int) -> list[Tag]:
     """Fetch all class tags for a specific date.
 


### PR DESCRIPTION
- this was a bad suggestion from sourcery
- we need to refresh the class tags in order to know when we can enroll

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request removes the caching mechanism from the get_classes_tags function to ensure that class tags are refreshed and accurate, addressing an issue with outdated class tag information.

- **Bug Fixes**:
    - Removed caching from the get_classes_tags function to ensure class tags are refreshed and up-to-date.

<!-- Generated by sourcery-ai[bot]: end summary -->