### PR TITLE
chore: Adjust scheduled workflow timing and increase enrollment timeout

### DIFF
--- a/.github/workflows/scheduled_holiday_runs.yml
+++ b/.github/workflows/scheduled_holiday_runs.yml
@@ -7,16 +7,16 @@ on: # yamllint disable-line rule:truthy
     # Sexta-Feira Santa
     # Páscoa
     # DST starts
-    - cron: 50 8 23 4 * # 25 de Abril
-    - cron: 50 8 29 4 * # Dia do Trabalhador
+    - cron: 35 8 23 4 * # 25 de Abril
+    - cron: 35 8 29 4 * # Dia do Trabalhador
     # Corpo de Deus
     # Assunção de Nossa Senhora
-    - cron: 50 8 8 6 * # Dia de Portugal
-    - cron: 50 8 3 10 * # Implantação da República
+    - cron: 35 8 8 6 * # Dia de Portugal
+    - cron: 35 8 3 10 * # Implantação da República
     # DST ends
-    - cron: 50 9 30 10 * # Dia de Todos os Santos
-    - cron: 50 9 29 11 * # Restauração da Independência
-    - cron: 50 9 6 12 * # Dia da Imaculada Conceição
+    - cron: 35 9 30 10 * # Dia de Todos os Santos
+    - cron: 35 9 29 11 * # Restauração da Independência
+    - cron: 35 9 6 12 * # Dia da Imaculada Conceição
     # Natal
 
 jobs:
@@ -43,6 +43,7 @@ jobs:
           class-time: 10:00
           class-type: Weekend WOD Rato
           class-date-offset-days: 2
+          timeout-seconds: 1800
           phpsessid: ${{ secrets.PHPSESSID }}
           regybox-user: ${{ secrets.REGYBOX_USER }}
           calendar-url: ${{ secrets.CALENDAR_URL }}

--- a/.github/workflows/scheduled_runs.yml
+++ b/.github/workflows/scheduled_runs.yml
@@ -4,9 +4,9 @@ on: # yamllint disable-line rule:truthy
   workflow_dispatch:
   schedule: # 60 hours in advance for morning classes
     # standard time, will be off on the last week of march
-    - cron: 15 18 * 1-3,11-12 5-6,0-2
+    - cron: 0 18 * 1-3,11-12 5-6,0-2
     # daylight saving time, will be off on the last week of october
-    - cron: 15 17 * 4-10 5-6,0-2
+    - cron: 0 17 * 4-10 5-6,0-2
 
 jobs:
   enroll:
@@ -19,6 +19,7 @@ jobs:
           class-time: 06:30
           class-type: WOD Rato
           class-date-offset-days: 3
+          timeout-seconds: 1800
           phpsessid: ${{ secrets.PHPSESSID }}
           regybox-user: ${{ secrets.REGYBOX_USER }}
           calendar-url: ${{ secrets.CALENDAR_URL }}


### PR DESCRIPTION
### Motivation
- Move scheduled GitHub Actions runs 15 minutes earlier to give the job lead time before class enrollment opens.  
- Increase the action-run enrollment timeout to allow more time for the enrollment process to complete (set to 1800 seconds).  

### Description
- Updated `.github/workflows/scheduled_runs.yml` to change cron minute values from `15` to `0` for the two scheduled entries and added `timeout-seconds: 1800` to the action `with` block.  
- Updated `.github/workflows/scheduled_holiday_runs.yml` to change cron minute values from `50` to `35` for holiday entries and added `timeout-seconds: 1800` to the action `with` block.  
- Changes are committed to the branch and prepared as this PR.  

### Testing
- Ran `make lint`, where most lint checks passed but `uv run tombi check` failed due to an external catalog fetch error (`https://www.schemastore.org/api/json/catalog.json` returned HTTP 403) causing `make lint` to exit non-zero.  
- Ran `make typecheck` which completed successfully.  
- Ran `make test` which completed successfully with `99 passed` and coverage `95.19%`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25cb1ac908833198a8d6dff5a71c4b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted scheduled automation trigger times for improved system performance and reliability
  * Added timeout configurations to automated workflow steps to enhance stability and prevent long-running processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->