### PR TITLE
feat: add Cloudflare calendar sync

### DIFF
--- a/.github/workflows/calendar_sync.yml
+++ b/.github/workflows/calendar_sync.yml
@@ -1,0 +1,64 @@
+---
+name: Sync Regybox Calendar
+on: # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Log planned changes without mutating Regybox or KV.
+        required: false
+        type: boolean
+        default: false
+      lookahead-days:
+        description: Number of days ahead to inspect.
+        required: false
+        default: "3"
+      enroll-window-minutes:
+        description: Enroll classes open now or opening within this many minutes.
+        required: false
+        default: "30"
+      calendar-event-names:
+        description: Comma-separated calendar event titles to sync.
+        required: true
+      target-class-types:
+        description: Comma-separated Regybox class names to target.
+        required: true
+
+jobs:
+  sync:
+    name: Sync calendar-backed enrollments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Sync Regybox enrollments
+        shell: bash
+        env:
+          PHPSESSID: ${{ secrets.PHPSESSID }}
+          REGYBOX_USER: ${{ secrets.REGYBOX_USER }}
+          CALENDAR_URL: ${{ secrets.CALENDAR_URL }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_KV_NAMESPACE_ID: ${{ secrets.CF_KV_NAMESPACE_ID }}
+          CF_KV_API_TOKEN: ${{ secrets.CF_KV_API_TOKEN }}
+          INPUT_DRY_RUN: ${{ inputs.dry-run }}
+          INPUT_LOOKAHEAD_DAYS: ${{ inputs.lookahead-days }}
+          INPUT_ENROLL_WINDOW_MINUTES: ${{ inputs.enroll-window-minutes }}
+          INPUT_CALENDAR_EVENT_NAMES: ${{ inputs.calendar-event-names }}
+          INPUT_TARGET_CLASS_TYPES: ${{ inputs.target-class-types }}
+        run: |
+          set -euo pipefail
+          args=(
+            "--calendar-event-names"
+            "${INPUT_CALENDAR_EVENT_NAMES}"
+            "--target-class-types"
+            "${INPUT_TARGET_CLASS_TYPES}"
+            "--lookahead-days"
+            "${INPUT_LOOKAHEAD_DAYS}"
+            "--enroll-window-minutes"
+            "${INPUT_ENROLL_WINDOW_MINUTES}"
+          )
+          if [[ "${INPUT_DRY_RUN}" == "true" ]]; then
+            args+=("--dry-run")
+          fi
+          uv run regybox-sync "${args[@]}"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ morning) or trigger it manually.
 
    ![Repository secrets list.](./static/repo-secrets.png)
 
+   > [!NOTE]
+   > If you want your calendar to drive enrollments and unenrollments on a 30-minute Cloudflare
+   > schedule, use the [Cloudflare calendar sync](#calendar-driven-sync-with-cloudflare) approach
+   > instead of a fixed-class GitHub schedule.
+
 3. Add the workflow file at `.github/workflows/regybox.yml` using the example below.
    Update the values under the `with:` section (class time, type, secrets, etc.) so they
    match your preferences.
@@ -100,7 +105,7 @@ morning) or trigger it manually.
 
 ![Generated Google App Password.](./static/app-password.png)
 
-### 4. Set Up Calendar Sync
+### 4. Set Up Calendar Checks
 
 You can optionally choose to have the auto-enroller check your personal calendar to confirm if
 there is a class scheduled at the desired time before attempting to enroll in the class. If no such
@@ -126,16 +131,246 @@ automatically in the class.
 > The calendar match is case-insensitive and ignores leading/trailing spaces. By default, the
 > action looks for an event whose title matches `CrossFit`.
 
+## Calendar-Driven Sync with Cloudflare
+
+GitHub scheduled workflows can run late. For calendar-driven syncing, use a Cloudflare Worker
+Cron Trigger to dispatch the GitHub workflow every 30 minutes instead of relying on GitHub's
+schedule queue.
+
+Calendar sync is different from the single-class auto-enroller:
+
+- It looks at your calendar over the next 3 days.
+- It maps calendar event titles to Regybox class names using required comma-separated lists that
+  you provide.
+- It enrolls in mapped classes that are open now or whose enrollment opens in the next 30 minutes.
+- It unenrolls from mapped Regybox classes that no longer have a matching calendar event.
+- It stores successful enrollments and waitlist placements in Cloudflare KV for 30 days. If you
+  manually unenroll from a class, the sync job will not re-enroll you while that cache entry exists.
+
+Add a workflow like this at `.github/workflows/calendar_sync.yml` in the repository that owns your
+automation:
+
+```yaml
+name: Sync Regybox Calendar
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        type: boolean
+        default: false
+      lookahead-days:
+        default: "3"
+      enroll-window-minutes:
+        default: "30"
+      calendar-event-names:
+        required: true
+      target-class-types:
+        required: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+      - name: Sync Regybox enrollments
+        env:
+          PHPSESSID: ${{ secrets.PHPSESSID }}
+          REGYBOX_USER: ${{ secrets.REGYBOX_USER }}
+          CALENDAR_URL: ${{ secrets.CALENDAR_URL }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_KV_NAMESPACE_ID: ${{ secrets.CF_KV_NAMESPACE_ID }}
+          CF_KV_API_TOKEN: ${{ secrets.CF_KV_API_TOKEN }}
+        run: >
+          uv run regybox-sync
+          --calendar-event-names '${{ inputs.calendar-event-names }}'
+          --target-class-types '${{ inputs.target-class-types }}'
+```
+
+`calendar-event-names` is a comma-separated list of calendar titles to sync. `target-class-types`
+is a comma-separated list of exact Regybox class names that any of those calendar events may
+correspond to:
+
+```text
+calendar-event-names: "Crossfit"
+target-class-types: "WOD"
+```
+
+You can provide more than one value by separating names with commas, for example
+`calendar-event-names: "Crossfit, Open Gym"` or `target-class-types: "WOD, Weekend WOD"`.
+
+### Cloudflare Setup
+
+You will configure two separate things:
+
+- GitHub Actions runs the actual Regybox sync and reads/writes Cloudflare KV.
+- Cloudflare Workers Cron Triggers only wake up every 30 minutes and dispatch the GitHub workflow.
+
+#### 1. Create the GitHub Workflow
+
+Commit `.github/workflows/calendar_sync.yml` in your automation repository. The workflow in this
+repository can be used as-is if your automation repository is this repo.
+
+After the workflow exists on the default branch, open **GitHub → Actions → Sync Regybox Calendar →
+Run workflow** once and enter:
+
+- `calendar-event-names`: the calendar titles to sync, for example `CrossFit`.
+- `target-class-types`: the exact Regybox class names those calendar events may target, for
+  example `WOD` or `WOD, Weekend WOD`.
+- `dry-run`: `true` for the first manual run.
+
+The dry run should start the workflow without enrolling or unenrolling anything.
+
+#### 2. Create a Cloudflare KV Namespace
+
+1. Open the [Cloudflare dashboard](https://dash.cloudflare.com/).
+2. Go to **Storage & databases → Workers KV**.
+3. Click **Create Instance**.
+4. Name it something like `regybox-sync-state`.
+5. Open the new KV instance and go to the **Metrics** tab.
+6. Copy the namespace ID. You will store it in GitHub as `CF_KV_NAMESPACE_ID`.
+
+#### 3. Create a Cloudflare API Token for GitHub Actions
+
+The GitHub sync workflow uses Cloudflare's REST API to read and write KV cache keys.
+
+1. In Cloudflare, go to **Manage account → Account API tokens**.
+2. Click **Create Token**.
+3. Name it `regybox-github-kv`.
+4. Add account-level permissions for **Workers KV Storage: Edit**.
+5. Click **Review token**.
+6. Click **Create token**.
+7. Copy **Account ID** and **Your API Token** from this screen.
+
+In GitHub, open **Settings → Secrets and variables → Actions** and add:
+
+- `CF_ACCOUNT_ID` — the **Account ID** value from Cloudflare.
+- `CF_KV_NAMESPACE_ID` — the KV namespace ID from step 2.
+- `CF_KV_API_TOKEN` — the **Your API Token** value from Cloudflare.
+
+#### 4. Create a GitHub Token for the Cloudflare Worker
+
+The Worker needs a GitHub token that can call the workflow dispatch endpoint.
+
+1. Open [GitHub fine-grained personal access tokens](https://github.com/settings/personal-access-tokens).
+2. Click **Generate new token**.
+3. Give the token a clear name, such as `regybox-cloudflare-dispatch`.
+4. Choose an expiration. Use **No expiration** if you do not want to rotate this token later.
+5. Set **Repository access** to only the repository containing `calendar_sync.yml`.
+6. Under repository permissions, set **Actions** to **Read and write**.
+7. Generate the token and copy it.
+
+#### 5. Create the Cloudflare Worker
+
+1. In Cloudflare, go to **Compute → Workers & Pages**.
+2. Click **Create application**.
+3. Click **Start with Hello World!**.
+4. Rename the Worker to `regybox-scheduler`.
+5. Click **Deploy**.
+6. Click **Edit code**.
+7. Paste this code into the `worker.js` tab:
+
+```js
+export default {
+  async scheduled(_event, env, _ctx) {
+    const url = `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/actions/workflows/${env.GITHUB_WORKFLOW}/dispatches`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "regybox-cloudflare-scheduler",
+      },
+      body: JSON.stringify({
+        ref: env.GITHUB_REF || "main",
+        inputs: {
+          "dry-run": "false",
+          "lookahead-days": "3",
+          "enroll-window-minutes": "30",
+          "calendar-event-names": env.CALENDAR_EVENT_NAMES,
+          "target-class-types": env.TARGET_CLASS_TYPES,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub dispatch failed: ${response.status} ${await response.text()}`);
+    }
+  },
+};
+```
+
+8. Click **Deploy**.
+
+#### 6. Add Worker Variables and Secrets
+
+Go back to the Worker dashboard and open **Settings → Variables**.
+
+Add these as type **Text**:
+
+- `GITHUB_OWNER` — your GitHub account or organization name.
+- `GITHUB_REPO` — the name of the GitHub repository containing `calendar_sync.yml`.
+- `GITHUB_WORKFLOW` — workflow file name, usually `calendar_sync.yml`.
+- `GITHUB_REF` — branch or tag to dispatch, usually `main`.
+- `CALENDAR_EVENT_NAMES` — for example `Crossfit`.
+- `TARGET_CLASS_TYPES` — for example `WOD`.
+
+Add this as type **Secret**:
+
+- `GITHUB_TOKEN` — the GitHub fine-grained token from step 4.
+
+After all variables and secrets are set, click **Deploy**.
+
+#### 7. Add the Cron Trigger
+
+Cloudflare Cron Triggers use UTC. To run every 30 minutes:
+
+1. Open the Worker in Cloudflare.
+2. Stay in the **Settings** tab.
+3. In **Trigger events**, click **Add → Cron triggers**.
+4. Open the **Cron expression** tab and paste:
+
+   ```cron
+   */30 * * * *
+   ```
+
+5. Click **Add**.
+
+Cloudflare says Cron Trigger changes can take several minutes to propagate. Wait up to 15 minutes
+before assuming the trigger is broken.
+
+#### 8. Test the Setup
+
+1. In Cloudflare, open the Worker logs.
+2. Click **Workers & Pages → regybox-scheduler → Logs**.
+3. Temporarily change the Worker variable `GITHUB_REF` only if you want to dispatch a test branch.
+4. Either wait for the next 30-minute tick or use Cloudflare's Worker testing tools to invoke the
+   scheduled handler.
+5. In GitHub, open **Actions → Sync Regybox Calendar** and confirm a new run appears.
+6. Start with `dry-run: true` until you see the expected classes in the logs.
+
+Useful references:
+
+- [Cloudflare Cron Triggers](https://developers.cloudflare.com/workers/configuration/cron-triggers/)
+- [Cloudflare Worker secrets](https://developers.cloudflare.com/workers/configuration/secrets/)
+- [Cloudflare API tokens](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/)
+- [GitHub workflow dispatch API](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event)
+
 ## Summary of Secrets
 
-| Secret name      | Required | Description                                                                        |
-| ---------------- | :------: | ---------------------------------------------------------------------------------- |
-| `PHPSESSID`      |   Yes    | Value of the `PHPSESSID` cookie from regybox.pt.                                   |
-| `REGYBOX_USER`   |   Yes    | Value of the `regybox_user` cookie from regybox.pt.                                |
-| `EMAIL_USERNAME` |  Yes\*   | Email address that sends confirmations. Required if `send-email` is `true`.        |
-| `EMAIL_PASSWORD` |  Yes\*   | Password or app password for `EMAIL_USERNAME`. Required if `send-email` is `true`. |
-| `EMAIL_TO`       |  Yes\*   | Email address that receives confirmations. Required if `send-email` is `true`.     |
-| `CALENDAR_URL`   |    No    | Secret `.ics` feed URL for your calendar. Enables calendar sync.                   |
+| Secret name          | Required | Description                                                                        |
+| -------------------- | :------: | ---------------------------------------------------------------------------------- |
+| `PHPSESSID`          |   Yes    | Value of the `PHPSESSID` cookie from regybox.pt.                                   |
+| `REGYBOX_USER`       |   Yes    | Value of the `regybox_user` cookie from regybox.pt.                                |
+| `EMAIL_USERNAME`     |  Yes\*   | Email address that sends confirmations. Required if `send-email` is `true`.        |
+| `EMAIL_PASSWORD`     |  Yes\*   | Password or app password for `EMAIL_USERNAME`. Required if `send-email` is `true`. |
+| `EMAIL_TO`           |  Yes\*   | Email address that receives confirmations. Required if `send-email` is `true`.     |
+| `CALENDAR_URL`       |    No    | Secret `.ics` feed URL for your calendar. Enables calendar sync.                   |
+| `CF_ACCOUNT_ID`      |   Sync   | Cloudflare account ID used by calendar-driven sync.                                |
+| `CF_KV_NAMESPACE_ID` |   Sync   | Cloudflare KV namespace ID used by calendar-driven sync.                           |
+| `CF_KV_API_TOKEN`    |   Sync   | Cloudflare API token with read/write access to the sync KV namespace.              |
 
 > [!TIP]
 > After committing the workflow, open the **Actions** tab and run it once with **Run workflow** to

--- a/README.md
+++ b/README.md
@@ -193,12 +193,12 @@ is a comma-separated list of exact Regybox class names that any of those calenda
 correspond to:
 
 ```text
-calendar-event-names: "Crossfit"
+calendar-event-names: "CrossFit"
 target-class-types: "WOD"
 ```
 
 You can provide more than one value by separating names with commas, for example
-`calendar-event-names: "Crossfit, Open Gym"` or `target-class-types: "WOD, Weekend WOD"`.
+`calendar-event-names: "CrossFit, Open Gym"` or `target-class-types: "WOD, Weekend WOD"`.
 
 ### Cloudflare Setup
 
@@ -314,7 +314,7 @@ Add these as type **Text**:
 - `GITHUB_REPO` — the name of the GitHub repository containing `calendar_sync.yml`.
 - `GITHUB_WORKFLOW` — workflow file name, usually `calendar_sync.yml`.
 - `GITHUB_REF` — branch or tag to dispatch, usually `main`.
-- `CALENDAR_EVENT_NAMES` — for example `Crossfit`.
+- `CALENDAR_EVENT_NAMES` — for example `CrossFit`.
 - `TARGET_CLASS_TYPES` — for example `WOD`.
 
 Add this as type **Secret**:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 [project.scripts]
 list = "regybox.__main__:run_list"
 regybox = "regybox.__main__:run"
+regybox-sync = "regybox.__main__:run_sync"
 
 [dependency-groups]
 dev = [

--- a/src/regybox/__main__.py
+++ b/src/regybox/__main__.py
@@ -25,6 +25,7 @@ import sys
 from regybox.common import LOGGER
 from regybox.exceptions import REGYBOX_USER_ERROR_PREFIX, RegyboxBaseError
 from regybox.regybox import list_classes, main
+from regybox.sync import CloudflareKVStore, sync_calendar
 
 
 def _log_user_error(error: RegyboxBaseError) -> None:
@@ -86,6 +87,68 @@ def run_list() -> None:
         sys.exit(1)
     except ValueError as e:
         LOGGER.error(f"Invalid date format. Expected YYYY-MM-DD: {e}")
+        sys.exit(1)
+
+
+def run_sync() -> None:
+    """Run calendar-driven Regybox sync."""
+    parser = argparse.ArgumentParser(
+        prog="regybox-sync",
+        description="Sync Regybox enrollments with mapped calendar events.",
+    )
+    parser.add_argument(
+        "--calendar-event-names",
+        required=True,
+        help=("Comma-separated calendar event titles to sync, e.g. 'CrossFit, Open Gym'."),
+    )
+    parser.add_argument(
+        "--target-class-types",
+        required=True,
+        help=(
+            "Comma-separated Regybox class names that matching calendar events may target, e.g."
+            " 'WOD, Open Gym'."
+        ),
+    )
+    parser.add_argument(
+        "--lookahead-days",
+        type=int,
+        default=3,
+        help="How many days ahead to inspect in the calendar and Regybox.",
+    )
+    parser.add_argument(
+        "--enroll-window-minutes",
+        type=int,
+        default=30,
+        help=(
+            "Only enroll classes that are open or whose enrollment opens within this many minutes."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log planned changes without enrolling, unenrolling, or writing KV state.",
+    )
+    args = parser.parse_args()
+    if args.lookahead_days <= 0:
+        LOGGER.error("lookahead-days must be a positive integer.")
+        sys.exit(1)
+    if args.enroll_window_minutes <= 0:
+        LOGGER.error("enroll-window-minutes must be a positive integer.")
+        sys.exit(1)
+    try:
+        sync_calendar(
+            store=CloudflareKVStore.from_env(),
+            calendar_event_names=args.calendar_event_names,
+            target_class_types=args.target_class_types,
+            lookahead_days=args.lookahead_days,
+            enroll_window_minutes=args.enroll_window_minutes,
+            dry_run=args.dry_run,
+        )
+    except RegyboxBaseError as e:
+        _log_user_error(e)
+        sys.exit(1)
+    except (TypeError, ValueError) as e:
+        LOGGER.error(e)
         sys.exit(1)
 
 

--- a/src/regybox/sync.py
+++ b/src/regybox/sync.py
@@ -3,6 +3,7 @@
 import datetime
 import hashlib
 import os
+import time
 from dataclasses import dataclass
 from typing import Protocol
 from urllib.parse import parse_qsl, quote, urlencode, urlparse
@@ -154,7 +155,8 @@ def class_cache_key(enroll_url: str) -> str:
         A stable cache key derived from generic URL parameters.
     """
     parsed_url = urlparse(enroll_url)
-    params = dict(parse_qsl(parsed_url.query, keep_blank_values=True))
+    query_items = parse_qsl(parsed_url.query, keep_blank_values=True)
+    params = dict(query_items)
     if params.get("x"):
         key_parts = [
             f"{name}={params[name]}" for name in ("data", "id_aula", "x") if params.get(name)
@@ -162,9 +164,7 @@ def class_cache_key(enroll_url: str) -> str:
         return f"regybox-sync:v1:enroll:x:{':'.join(key_parts)}"
 
     canonical_params = [
-        (name, value)
-        for name, value in parse_qsl(parsed_url.query, keep_blank_values=True)
-        if name not in VOLATILE_CACHE_PARAMS
+        (name, value) for name, value in query_items if name not in VOLATILE_CACHE_PARAMS
     ]
     canonical_params.sort()
     canonical = f"{parsed_url.path}?{urlencode(canonical_params)}"
@@ -217,7 +217,7 @@ def sync_calendar(
         dry_run=dry_run,
     )
 
-    for class_ in _mapped_enrolled_classes(classes_by_date, class_map):
+    for class_ in _mapped_enrolled_classes(classes_by_date, class_map, started_at, ends_at):
         if _has_matching_calendar_event(class_, planned_classes):
             continue
         LOGGER.info("Unenrolling from %s on %s at %s", class_.name, class_.date, class_.start)
@@ -272,8 +272,22 @@ def _sync_enrollments(
         if enrollment == "already_enrolled":
             continue
         if enrollment == "not_ready":
-            skipped_not_ready += 1
-            continue
+            class_ = _wait_for_enroll_url(
+                class_,
+                planned,
+                classes_by_date,
+                enroll_window_seconds=enroll_window_seconds,
+            )
+            enrollment = _enrollment_decision(
+                class_,
+                store=store,
+                enroll_window_seconds=enroll_window_seconds,
+            )
+            if enrollment == "already_enrolled":
+                continue
+            if enrollment == "not_ready":
+                skipped_not_ready += 1
+                continue
         if enrollment == "cached":
             skipped_cached += 1
             continue
@@ -382,9 +396,57 @@ def _enrollment_decision(
     return cache_key
 
 
+def _wait_for_enroll_url(
+    class_: Class,
+    planned: PlannedClass,
+    classes_by_date: dict[datetime.date, list[Class]],
+    *,
+    enroll_window_seconds: int,
+) -> Class:
+    if (
+        class_.enroll_url is not None
+        or class_.is_open
+        or class_.time_to_enroll is None
+        or class_.time_to_enroll > enroll_window_seconds
+    ):
+        return class_
+    if class_.time_to_enroll > 0:
+        LOGGER.info(
+            "Waiting %s seconds for enrollment to open for %s on %s at %s",
+            class_.time_to_enroll,
+            class_.name,
+            class_.date,
+            class_.start,
+        )
+        time.sleep(class_.time_to_enroll)
+    refreshed_date = planned.starts_at.date()
+    classes_by_date[refreshed_date] = get_classes(
+        refreshed_date.year, refreshed_date.month, refreshed_date.day
+    )
+    return _find_planned_regybox_class(planned, classes_by_date) or class_
+
+
+def _class_starts_in_window(
+    class_: Class, start: datetime.datetime, end: datetime.datetime
+) -> bool:
+    try:
+        class_start = datetime.datetime.fromisoformat(f"{class_.date}T{class_.start}")
+    except ValueError:
+        LOGGER.warning(
+            "Skipping unenrollment window check for class with invalid date/time: %s %s",
+            class_.date,
+            class_.start,
+        )
+        return False
+    class_start = class_start.replace(tzinfo=TIMEZONE)
+    return start <= class_start < end
+
+
 def _mapped_enrolled_classes(
     classes_by_date: dict[datetime.date, list[Class]],
     class_map: dict[str, tuple[str, ...]],
+    start: datetime.datetime,
+    end: datetime.datetime,
 ) -> list[Class]:
     mapped_names = {name.casefold() for names in class_map.values() for name in names}
     enrolled: list[Class] = []
@@ -392,6 +454,8 @@ def _mapped_enrolled_classes(
     for classes in classes_by_date.values():
         for class_ in classes:
             if class_.name.casefold() not in mapped_names:
+                continue
+            if not _class_starts_in_window(class_, start, end):
                 continue
             if class_.user_is_enrolled or class_.user_is_waitlisted:
                 signature = (class_.date, class_.start, class_.name.casefold())

--- a/src/regybox/sync.py
+++ b/src/regybox/sync.py
@@ -1,0 +1,418 @@
+"""Calendar-driven Regybox enrollment synchronization."""
+
+import datetime
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.parse import parse_qsl, quote, urlencode, urlparse
+
+import icalendar
+import requests
+
+from regybox.cal import Calendar
+from regybox.classes import Class, get_classes
+from regybox.common import LOGGER, TIMEZONE
+from regybox.exceptions import UserAlreadyEnrolledError
+
+KV_TTL_SECONDS: int = 30 * 24 * 60 * 60
+KV_API_BASE_URL: str = "https://api.cloudflare.com/client/v4"
+HTTP_NOT_FOUND: int = 404
+VOLATILE_CACHE_PARAMS: frozenset[str] = frozenset({"id_rato", "box", "plano"})
+
+
+class SyncStore(Protocol):
+    """State store for successful automatic enrollment attempts."""
+
+    def seen(self, key: str) -> bool:
+        """Return whether a successful enrollment key is stored."""
+        ...
+
+    def mark_success(self, key: str) -> None:
+        """Persist a successful enrollment key."""
+        ...
+
+
+@dataclass(frozen=True)
+class SyncResult:
+    """Summary of one sync pass."""
+
+    calendar_events: int = 0
+    enrolled: int = 0
+    unenrolled: int = 0
+    skipped_cached: int = 0
+    skipped_not_ready: int = 0
+
+
+@dataclass(frozen=True)
+class PlannedClass:
+    """A calendar event translated into one or more Regybox class names."""
+
+    starts_at: datetime.datetime
+    class_names: tuple[str, ...]
+
+
+class CloudflareKVStore:
+    """Cloudflare KV-backed sync state store."""
+
+    def __init__(
+        self,
+        *,
+        account_id: str,
+        namespace_id: str,
+        api_token: str,
+        session: requests.Session | None = None,
+    ) -> None:
+        """Initialize a Cloudflare KV store."""
+        self.account_id = account_id
+        self.namespace_id = namespace_id
+        self.api_token = api_token
+        self.session = session if session is not None else requests.Session()
+
+    @classmethod
+    def from_env(cls) -> "CloudflareKVStore":
+        """Create a Cloudflare KV store from environment variables.
+
+        Returns:
+            A Cloudflare KV store configured from environment variables.
+
+        Raises:
+            ValueError: If any required Cloudflare environment variable is
+                missing.
+        """
+        missing = [
+            name
+            for name in ("CF_ACCOUNT_ID", "CF_KV_NAMESPACE_ID", "CF_KV_API_TOKEN")
+            if not os.environ.get(name)
+        ]
+        if missing:
+            raise ValueError(f"Missing Cloudflare KV environment variables: {', '.join(missing)}")
+        return cls(
+            account_id=os.environ["CF_ACCOUNT_ID"],
+            namespace_id=os.environ["CF_KV_NAMESPACE_ID"],
+            api_token=os.environ["CF_KV_API_TOKEN"],
+        )
+
+    def _value_url(self, key: str) -> str:
+        encoded_key = quote(key, safe="")
+        return (
+            f"{KV_API_BASE_URL}/accounts/{self.account_id}/storage/kv/namespaces/"
+            f"{self.namespace_id}/values/{encoded_key}"
+        )
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_token}"}
+
+    def seen(self, key: str) -> bool:
+        """Return whether the key already exists in KV."""
+        response = self.session.get(self._value_url(key), headers=self._headers, timeout=10)
+        if response.status_code == HTTP_NOT_FOUND:
+            return False
+        response.raise_for_status()
+        return True
+
+    def mark_success(self, key: str) -> None:
+        """Store a successful automatic enrollment marker with a 30-day TTL."""
+        response = self.session.put(
+            self._value_url(key),
+            data="1",
+            headers=self._headers,
+            params={"expiration_ttl": str(KV_TTL_SECONDS)},
+            timeout=10,
+        )
+        response.raise_for_status()
+
+
+def build_class_map(
+    calendar_event_names: str | None,
+    target_class_types: str | None,
+) -> dict[str, tuple[str, ...]]:
+    """Build calendar-summary-to-Regybox-class mappings from CSV arguments.
+
+    Returns:
+        A case-folded mapping of calendar summary to Regybox class names.
+    """
+    event_names = _parse_csv_arg(calendar_event_names, arg_name="calendar-event-names")
+    class_types = tuple(_parse_csv_arg(target_class_types, arg_name="target-class-types"))
+    return {event_name.casefold(): class_types for event_name in event_names}
+
+
+def _parse_csv_arg(value: str | None, *, arg_name: str) -> list[str]:
+    if value is None:
+        raise ValueError(f"{arg_name} must be provided")
+    parts = [part.strip() for part in value.split(",") if part.strip()]
+    if not parts:
+        raise ValueError(f"{arg_name} must include at least one value")
+    return parts
+
+
+def class_cache_key(enroll_url: str) -> str:
+    """Build a generic, stable cache key for a Regybox enrollment URL.
+
+    Returns:
+        A stable cache key derived from generic URL parameters.
+    """
+    parsed_url = urlparse(enroll_url)
+    params = dict(parse_qsl(parsed_url.query, keep_blank_values=True))
+    if params.get("x"):
+        key_parts = [
+            f"{name}={params[name]}" for name in ("data", "id_aula", "x") if params.get(name)
+        ]
+        return f"regybox-sync:v1:enroll:x:{':'.join(key_parts)}"
+
+    canonical_params = [
+        (name, value)
+        for name, value in parse_qsl(parsed_url.query, keep_blank_values=True)
+        if name not in VOLATILE_CACHE_PARAMS
+    ]
+    canonical_params.sort()
+    canonical = f"{parsed_url.path}?{urlencode(canonical_params)}"
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"regybox-sync:v1:enroll:hash:{digest}"
+
+
+def sync_calendar(
+    *,
+    store: SyncStore,
+    calendar_event_names: str | None = None,
+    target_class_types: str | None = None,
+    lookahead_days: int = 3,
+    enroll_window_minutes: int = 30,
+    dry_run: bool = False,
+    now: datetime.datetime | None = None,
+) -> SyncResult:
+    """Sync Regybox enrollments to mapped calendar events.
+
+    Returns:
+        Summary counts for the sync pass.
+
+    Raises:
+        ValueError: If numeric options are not positive or mapping arguments
+            are invalid.
+    """
+    if lookahead_days <= 0:
+        raise ValueError("lookahead-days must be positive")
+    if enroll_window_minutes <= 0:
+        raise ValueError("enroll-window-minutes must be positive")
+
+    started_at = now if now is not None else datetime.datetime.now(TIMEZONE)
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=TIMEZONE)
+    ends_at = started_at + datetime.timedelta(days=lookahead_days)
+    class_map = build_class_map(calendar_event_names, target_class_types)
+    calendar = Calendar()
+    if not calendar.calendar:
+        raise ValueError("calendar sync requires CALENDAR_URL to be configured")
+    planned_classes = _planned_classes(calendar, started_at, ends_at, class_map)
+    classes_by_date = _classes_by_date(started_at, ends_at)
+
+    unenrolled = 0
+    enroll_window_seconds = enroll_window_minutes * 60
+    enrolled, skipped_cached, skipped_not_ready = _sync_enrollments(
+        planned_classes,
+        classes_by_date=classes_by_date,
+        store=store,
+        enroll_window_seconds=enroll_window_seconds,
+        dry_run=dry_run,
+    )
+
+    for class_ in _mapped_enrolled_classes(classes_by_date, class_map):
+        if _has_matching_calendar_event(class_, planned_classes):
+            continue
+        LOGGER.info("Unenrolling from %s on %s at %s", class_.name, class_.date, class_.start)
+        if not dry_run:
+            class_.unenroll()
+        unenrolled += 1
+
+    result = SyncResult(
+        calendar_events=len(planned_classes),
+        enrolled=enrolled,
+        unenrolled=unenrolled,
+        skipped_cached=skipped_cached,
+        skipped_not_ready=skipped_not_ready,
+    )
+    LOGGER.info(
+        "Sync result: calendar_events=%s enrolled=%s unenrolled=%s skipped_cached=%s"
+        " skipped_not_ready=%s",
+        result.calendar_events,
+        result.enrolled,
+        result.unenrolled,
+        result.skipped_cached,
+        result.skipped_not_ready,
+    )
+    return result
+
+
+def _sync_enrollments(
+    planned_classes: list[PlannedClass],
+    *,
+    classes_by_date: dict[datetime.date, list[Class]],
+    store: SyncStore,
+    enroll_window_seconds: int,
+    dry_run: bool,
+) -> tuple[int, int, int]:
+    enrolled = 0
+    skipped_cached = 0
+    skipped_not_ready = 0
+
+    for planned in planned_classes:
+        class_ = _find_planned_regybox_class(planned, classes_by_date)
+        if class_ is None:
+            LOGGER.info(
+                "No mapped Regybox class found for calendar event at %s",
+                planned.starts_at.isoformat(),
+            )
+            continue
+        enrollment = _enrollment_decision(
+            class_,
+            store=store,
+            enroll_window_seconds=enroll_window_seconds,
+        )
+        if enrollment == "already_enrolled":
+            continue
+        if enrollment == "not_ready":
+            skipped_not_ready += 1
+            continue
+        if enrollment == "cached":
+            skipped_cached += 1
+            continue
+        LOGGER.info("Enrolling in %s on %s at %s", class_.name, class_.date, class_.start)
+        if not dry_run:
+            try:
+                class_.enroll()
+            except UserAlreadyEnrolledError:
+                LOGGER.info("Already enrolled in class")
+            store.mark_success(enrollment)
+        enrolled += 1
+
+    return enrolled, skipped_cached, skipped_not_ready
+
+
+def _planned_classes(
+    calendar: Calendar,
+    start: datetime.datetime,
+    end: datetime.datetime,
+    class_map: dict[str, tuple[str, ...]],
+) -> list[PlannedClass]:
+    events = calendar.interval(start, end)
+    planned: list[PlannedClass] = []
+    for event in events:
+        summary = _event_summary(event)
+        if summary is None:
+            continue
+        class_names = class_map.get(summary.casefold())
+        if class_names is None:
+            continue
+        starts_at = _event_start(event)
+        if starts_at is None:
+            continue
+        planned.append(PlannedClass(starts_at=starts_at, class_names=class_names))
+    return planned
+
+
+def _event_summary(event: icalendar.cal.Event) -> str | None:
+    summary = event.get("SUMMARY")
+    if summary is None:
+        return None
+    normalized = str(summary).strip()
+    return normalized or None
+
+
+def _event_start(event: icalendar.cal.Event) -> datetime.datetime | None:
+    dt = event["DTSTART"].dt
+    if isinstance(dt, datetime.datetime):
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=TIMEZONE)
+        return dt.astimezone(TIMEZONE)
+    return None
+
+
+def _classes_by_date(
+    start: datetime.datetime,
+    end: datetime.datetime,
+) -> dict[datetime.date, list[Class]]:
+    dates: list[datetime.date] = []
+    current = start.date()
+    while current <= end.date():
+        dates.append(current)
+        current += datetime.timedelta(days=1)
+
+    classes_by_date: dict[datetime.date, list[Class]] = {}
+    for date in dates:
+        classes_by_date[date] = get_classes(date.year, date.month, date.day)
+    return classes_by_date
+
+
+def _find_planned_regybox_class(
+    planned: PlannedClass,
+    classes_by_date: dict[datetime.date, list[Class]],
+) -> Class | None:
+    class_date = planned.starts_at.date()
+    class_time = planned.starts_at.strftime("%H:%M")
+    mapped_names = {name.casefold() for name in planned.class_names}
+    for class_ in classes_by_date.get(class_date, []):
+        if class_.start == class_time and class_.name.casefold() in mapped_names:
+            return class_
+    return None
+
+
+def _class_is_enrollable_now(class_: Class, enroll_window_seconds: int) -> bool:
+    if class_.is_open:
+        return True
+    return class_.time_to_enroll is not None and class_.time_to_enroll <= enroll_window_seconds
+
+
+def _enrollment_decision(
+    class_: Class,
+    *,
+    store: SyncStore,
+    enroll_window_seconds: int,
+) -> str:
+    """Return an enrollment action token or skip reason."""
+    if class_.user_is_enrolled or class_.user_is_waitlisted:
+        return "already_enrolled"
+    if not _class_is_enrollable_now(class_, enroll_window_seconds):
+        return "not_ready"
+    if class_.enroll_url is None:
+        return "not_ready"
+    cache_key = class_cache_key(class_.enroll_url)
+    if store.seen(cache_key):
+        return "cached"
+    return cache_key
+
+
+def _mapped_enrolled_classes(
+    classes_by_date: dict[datetime.date, list[Class]],
+    class_map: dict[str, tuple[str, ...]],
+) -> list[Class]:
+    mapped_names = {name.casefold() for names in class_map.values() for name in names}
+    enrolled: list[Class] = []
+    seen: set[tuple[str, str, str]] = set()
+    for classes in classes_by_date.values():
+        for class_ in classes:
+            if class_.name.casefold() not in mapped_names:
+                continue
+            if class_.user_is_enrolled or class_.user_is_waitlisted:
+                signature = (class_.date, class_.start, class_.name.casefold())
+                if signature in seen:
+                    continue
+                seen.add(signature)
+                enrolled.append(class_)
+    return enrolled
+
+
+def _has_matching_calendar_event(
+    class_: Class,
+    planned_classes: list[PlannedClass],
+) -> bool:
+    class_name = class_.name.casefold()
+    for planned in planned_classes:
+        if class_name not in {name.casefold() for name in planned.class_names}:
+            continue
+        if (
+            planned.starts_at.date().isoformat() == class_.date
+            and planned.starts_at.strftime("%H:%M") == class_.start
+        ):
+            return True
+    return False

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -9,3 +9,15 @@ def test_email_sender_preserves_display_name_with_valid_address() -> None:
     action_text = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
 
     assert "from: ${{ inputs.email-from-name }} <${{ inputs.email-username }}>" in action_text
+
+
+def test_calendar_sync_workflow_exposes_dispatch_and_kv_inputs() -> None:
+    workflow_text = (REPO_ROOT / ".github/workflows/calendar_sync.yml").read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow_text
+    assert "uv run regybox-sync" in workflow_text
+    assert "calendar-event-names:" in workflow_text
+    assert "target-class-types:" in workflow_text
+    assert "CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}" in workflow_text
+    assert "CF_KV_NAMESPACE_ID: ${{ secrets.CF_KV_NAMESPACE_ID }}" in workflow_text
+    assert "CF_KV_API_TOKEN: ${{ secrets.CF_KV_API_TOKEN }}" in workflow_text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from regybox import __main__ as cli
-from regybox.exceptions import REGYBOX_USER_ERROR_PREFIX, RegyboxLoginError
+from regybox.exceptions import REGYBOX_USER_ERROR_PREFIX, ClassNotOpenError, RegyboxLoginError
 
 
 def test_run_calls_main_with_parsed_args(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -139,5 +139,174 @@ def test_run_list_exits_on_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", ["list", "not-a-date"])
     with pytest.raises(SystemExit) as exc_info:
         cli.run_list()
+
+    assert exc_info.value.code == 1
+
+
+def test_run_sync_requires_calendar_event_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["regybox-sync"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.run_sync()
+
+    assert exc_info.value.code == 2
+
+
+def test_run_sync_requires_target_class_types(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["regybox-sync", "--calendar-event-names", "Crossfit"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.run_sync()
+
+    assert exc_info.value.code == 2
+
+
+def test_run_sync_calls_sync_with_required_mapping_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "regybox-sync",
+            "--calendar-event-names",
+            "Crossfit",
+            "--target-class-types",
+            "WOD Rato",
+        ],
+    )
+    with (
+        patch("regybox.__main__.CloudflareKVStore.from_env") as store_from_env,
+        patch("regybox.__main__.sync_calendar") as mock_sync_calendar,
+    ):
+        cli.run_sync()
+
+    mock_sync_calendar.assert_called_once_with(
+        store=store_from_env.return_value,
+        calendar_event_names="Crossfit",
+        target_class_types="WOD Rato",
+        lookahead_days=3,
+        enroll_window_minutes=30,
+        dry_run=False,
+    )
+
+
+def test_run_sync_passes_custom_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "regybox-sync",
+            "--calendar-event-names",
+            "Crossfit, Open Gym",
+            "--target-class-types",
+            "WOD Rato, Weekend WOD Rato",
+            "--lookahead-days",
+            "4",
+            "--enroll-window-minutes",
+            "20",
+            "--dry-run",
+        ],
+    )
+    with (
+        patch("regybox.__main__.CloudflareKVStore.from_env") as store_from_env,
+        patch("regybox.__main__.sync_calendar") as mock_sync_calendar,
+    ):
+        cli.run_sync()
+
+    mock_sync_calendar.assert_called_once_with(
+        store=store_from_env.return_value,
+        calendar_event_names="Crossfit, Open Gym",
+        target_class_types="WOD Rato, Weekend WOD Rato",
+        lookahead_days=4,
+        enroll_window_minutes=20,
+        dry_run=True,
+    )
+
+
+def test_run_sync_exits_on_invalid_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "regybox-sync",
+            "--calendar-event-names",
+            "Crossfit",
+            "--target-class-types",
+            "WOD Rato",
+            "--enroll-window-minutes",
+            "0",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.run_sync()
+
+    assert exc_info.value.code == 1
+
+
+def test_run_sync_exits_on_invalid_lookahead(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "regybox-sync",
+            "--calendar-event-names",
+            "Crossfit",
+            "--target-class-types",
+            "WOD Rato",
+            "--lookahead-days",
+            "0",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.run_sync()
+
+    assert exc_info.value.code == 1
+
+
+def test_run_sync_exits_on_known_regybox_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "regybox-sync",
+            "--calendar-event-names",
+            "Crossfit",
+            "--target-class-types",
+            "WOD Rato",
+        ],
+    )
+    with (
+        patch("regybox.__main__.CloudflareKVStore.from_env"),
+        patch("regybox.__main__.sync_calendar", side_effect=ClassNotOpenError()),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli.run_sync()
+
+    assert exc_info.value.code == 1
+
+
+def test_run_sync_exits_on_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "regybox-sync",
+            "--calendar-event-names",
+            "Crossfit",
+            "--target-class-types",
+            "WOD Rato",
+        ],
+    )
+    with (
+        patch("regybox.__main__.CloudflareKVStore.from_env"),
+        patch("regybox.__main__.sync_calendar", side_effect=ValueError("bad mapping")),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli.run_sync()
 
     assert exc_info.value.code == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -290,6 +290,30 @@ def test_run_sync_exits_on_known_regybox_error(monkeypatch: pytest.MonkeyPatch) 
     assert exc_info.value.code == 1
 
 
+def test_run_sync_exits_on_cloudflare_kv_env_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "regybox-sync",
+            "--calendar-event-names",
+            "Crossfit",
+            "--target-class-types",
+            "WOD Rato",
+        ],
+    )
+    with (
+        patch(
+            "regybox.__main__.CloudflareKVStore.from_env",
+            side_effect=ValueError("CF_ACCOUNT_ID"),
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        cli.run_sync()
+
+    assert exc_info.value.code == 1
+
+
 def test_run_sync_exits_on_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         sys,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -303,6 +303,65 @@ def test_sync_calendar_unenrolls_mapped_class_without_calendar_event() -> None:
     assert result.unenrolled == 1
 
 
+def test_sync_calendar_waits_and_refetches_class_opening_inside_enroll_window() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    event = _CalendarEvent("Crossfit", datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE))
+    pending = _class(is_open=False, time_to_enroll=0, enroll_url=None)
+    opened = _class(is_open=True, time_to_enroll=None)
+    store = MagicMock()
+    store.seen.return_value = False
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", side_effect=[[], [pending], [opened]]),
+        patch("regybox.sync.time.sleep") as sleep,
+    ):
+        calendar_cls.return_value.interval.return_value = [event]
+        result = sync_calendar(
+            store=store,
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+            lookahead_days=1,
+        )
+
+    sleep.assert_not_called()
+    opened.enroll.assert_called_once_with()
+    pending.enroll.assert_not_called()
+    assert result.enrolled == 1
+    assert result.skipped_not_ready == 0
+
+
+def test_sync_calendar_does_not_unenroll_mapped_class_outside_sync_window() -> None:
+    now = datetime.datetime(2026, 6, 17, 12, 0, tzinfo=TIMEZONE)
+    earlier_today = _class(
+        date="2026-06-17",
+        start="06:30",
+        user_is_enrolled=True,
+        enroll_url=None,
+        unenroll_url=(
+            "https://www.regybox.pt/app/app_nova/php/aulas/cancela_aula.php?"
+            "id_aula=63049&data=2026-06-17&x=0e0e5e2b0fed2e699ba91b3d6506"
+        ),
+    )
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[earlier_today]),
+    ):
+        calendar_cls.return_value.interval.return_value = []
+        result = sync_calendar(
+            store=MagicMock(),
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+            lookahead_days=1,
+        )
+
+    earlier_today.unenroll.assert_not_called()
+    assert result.unenrolled == 0
+
+
 def test_sync_calendar_leaves_unmapped_enrolled_class_alone() -> None:
     now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
     yoga = _class(name="Yoga", user_is_enrolled=True, enroll_url=None)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,493 @@
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from regybox.common import TIMEZONE
+from regybox.exceptions import UserAlreadyEnrolledError
+from regybox.sync import (
+    KV_TTL_SECONDS,
+    CloudflareKVStore,
+    build_class_map,
+    class_cache_key,
+    sync_calendar,
+)
+
+CALENDAR_EVENT_NAMES = "Crossfit"
+TARGET_CLASS_TYPES = "WOD Rato"
+
+
+def _class(  # noqa: PLR0913
+    *,
+    name: str = "WOD Rato",
+    date: str = "2026-06-18",
+    start: str = "06:30",
+    is_open: bool = True,
+    time_to_enroll: int | None = None,
+    user_is_enrolled: bool = False,
+    user_is_waitlisted: bool = False,
+    enroll_url: str | None = (
+        "https://www.regybox.pt/app/app_nova/php/aulas/marca_aulas.php?"
+        "id_aula=63049&data=2026-06-18&source=mes&ano=2026&id_rato=2120&"
+        "x=0e0e5e2b0fed2e699ba91b3d6506"
+    ),
+    unenroll_url: str | None = None,
+) -> MagicMock:
+    mock_class = MagicMock()
+    mock_class.name = name
+    mock_class.date = date
+    mock_class.start = start
+    mock_class.is_open = is_open
+    mock_class.time_to_enroll = time_to_enroll
+    mock_class.user_is_enrolled = user_is_enrolled
+    mock_class.user_is_waitlisted = user_is_waitlisted
+    mock_class.enroll_url = enroll_url
+    mock_class.unenroll_url = unenroll_url
+    mock_class.enroll.return_value = "Inscrito com sucesso"
+    mock_class.unenroll.return_value = "Cancelado"
+    return mock_class
+
+
+class _CalendarEvent:
+    def __init__(self, summary: str | None, when: datetime.datetime | datetime.date) -> None:
+        self.summary = summary
+        self.when = when
+
+    def get(self, key: str) -> str | None:
+        if key == "SUMMARY":
+            return self.summary
+        return None
+
+    def __getitem__(self, key: str) -> SimpleNamespace:
+        if key != "DTSTART":
+            raise KeyError(key)
+        return SimpleNamespace(dt=self.when)
+
+
+def test_class_cache_key_prefers_generic_x_and_ignores_box_specific_params() -> None:
+    first = (
+        "https://www.regybox.pt/app/app_nova/php/aulas/marca_aulas.php?"
+        "id_aula=63049&data=2026-06-17&source=mes&ano=2026&id_rato=2120&"
+        "x=0e0e5e2b0fed2e699ba91b3d6506"
+    )
+    reordered = (
+        "https://www.regybox.pt/app/app_nova/php/aulas/marca_aulas.php?"
+        "x=0e0e5e2b0fed2e699ba91b3d6506&id_rato=9999&data=2026-06-17&"
+        "id_aula=63049&ano=2026&source=mes"
+    )
+
+    assert class_cache_key(first) == class_cache_key(reordered)
+    assert class_cache_key(first) == (
+        "regybox-sync:v1:enroll:x:data=2026-06-17:id_aula=63049:x=0e0e5e2b0fed2e699ba91b3d6506"
+    )
+
+
+def test_class_cache_key_falls_back_to_canonical_hash_without_x() -> None:
+    first = (
+        "https://www.regybox.pt/app/app_nova/php/aulas/marca_aulas.php?"
+        "id_aula=63049&data=2026-06-17&id_rato=2120"
+    )
+    second = (
+        "https://www.regybox.pt/app/app_nova/php/aulas/marca_aulas.php?"
+        "id_rato=9999&data=2026-06-17&id_aula=63049"
+    )
+
+    assert class_cache_key(first) == class_cache_key(second)
+    assert class_cache_key(first).startswith("regybox-sync:v1:enroll:hash:")
+
+
+def test_build_class_map_requires_custom_args() -> None:
+    with pytest.raises(ValueError, match="calendar-event-names"):
+        build_class_map(None, TARGET_CLASS_TYPES)
+    with pytest.raises(ValueError, match="target-class-types"):
+        build_class_map(CALENDAR_EVENT_NAMES, None)
+
+    assert build_class_map("Crossfit, Open Gym", "WOD Rato, Weekend WOD Rato") == {
+        "crossfit": ("WOD Rato", "Weekend WOD Rato"),
+        "open gym": ("WOD Rato", "Weekend WOD Rato"),
+    }
+
+    with pytest.raises(ValueError, match="calendar-event-names"):
+        build_class_map(" , ", TARGET_CLASS_TYPES)
+    with pytest.raises(ValueError, match="target-class-types"):
+        build_class_map(CALENDAR_EVENT_NAMES, " , ")
+
+
+def test_cloudflare_kv_store_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CF_ACCOUNT_ID", "account")
+    monkeypatch.setenv("CF_KV_NAMESPACE_ID", "namespace")
+    monkeypatch.setenv("CF_KV_API_TOKEN", "api-token")
+
+    store = CloudflareKVStore.from_env()
+
+    assert store.account_id == "account"
+    assert store.namespace_id == "namespace"
+    assert store.api_token == "api-token"  # noqa: S105
+
+
+def test_cloudflare_kv_store_from_env_raises_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("CF_KV_NAMESPACE_ID", raising=False)
+    monkeypatch.delenv("CF_KV_API_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="CF_ACCOUNT_ID"):
+        CloudflareKVStore.from_env()
+
+
+def test_cloudflare_kv_store_seen_reads_existing_and_missing_keys() -> None:
+    session = MagicMock()
+    missing_response = MagicMock()
+    missing_response.status_code = 404
+    existing_response = MagicMock()
+    existing_response.status_code = 200
+    existing_response.raise_for_status = MagicMock()
+    session.get.side_effect = [missing_response, existing_response]
+    store = CloudflareKVStore(
+        account_id="account",
+        namespace_id="namespace",
+        api_token="api-token",  # noqa: S106
+        session=session,
+    )
+
+    assert store.seen("missing") is False
+    assert store.seen("existing") is True
+    existing_response.raise_for_status.assert_called_once_with()
+
+
+def test_cloudflare_kv_store_writes_success_with_30_day_ttl() -> None:
+    session = MagicMock()
+    put_response = MagicMock()
+    put_response.raise_for_status = MagicMock()
+    session.put.return_value = put_response
+    api_token = "test-api-token"  # noqa: S105
+    store = CloudflareKVStore(
+        account_id="account",
+        namespace_id="namespace",
+        api_token=api_token,
+        session=session,
+    )
+
+    store.mark_success("regybox-sync:v1:enroll:x:key")
+
+    session.put.assert_called_once()
+    assert session.put.call_args.kwargs["params"] == {"expiration_ttl": str(KV_TTL_SECONDS)}
+    assert session.put.call_args.kwargs["headers"]["Authorization"] == f"Bearer {api_token}"
+
+
+def test_sync_calendar_enrolls_open_calendar_class_and_caches_success() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    event = _CalendarEvent("Crossfit", datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE))
+    wod = _class()
+    store = MagicMock()
+    store.seen.return_value = False
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[wod]),
+    ):
+        calendar_cls.return_value.interval.return_value = [event]
+        result = sync_calendar(
+            store=store,
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+        )
+
+    wod.enroll.assert_called_once_with()
+    store.mark_success.assert_called_once()
+    assert result.enrolled == 1
+    assert result.skipped_cached == 0
+
+
+def test_sync_calendar_handles_already_enrolled_response_and_caches_success() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    event = _CalendarEvent("Crossfit", datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE))
+    wod = _class()
+
+    wod.enroll.side_effect = UserAlreadyEnrolledError()
+    store = MagicMock()
+    store.seen.return_value = False
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[wod]),
+    ):
+        calendar_cls.return_value.interval.return_value = [event]
+        result = sync_calendar(
+            store=store,
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+        )
+
+    wod.enroll.assert_called_once_with()
+    store.mark_success.assert_called_once()
+    assert result.enrolled == 1
+
+
+def test_sync_calendar_skips_cached_calendar_class() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    event = _CalendarEvent("Crossfit", datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE))
+    wod = _class()
+    store = MagicMock()
+    store.seen.return_value = True
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[wod]),
+    ):
+        calendar_cls.return_value.interval.return_value = [event]
+        result = sync_calendar(
+            store=store,
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+        )
+
+    wod.enroll.assert_not_called()
+    store.mark_success.assert_not_called()
+    assert result.skipped_cached == 1
+
+
+def test_sync_calendar_does_not_cache_failed_enrollment() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    event = _CalendarEvent("Crossfit", datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE))
+    wod = _class()
+    wod.enroll.side_effect = RuntimeError("website error")
+    store = MagicMock()
+    store.seen.return_value = False
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[wod]),
+    ):
+        calendar_cls.return_value.interval.return_value = [event]
+        with pytest.raises(RuntimeError, match="website error"):
+            sync_calendar(
+                store=store,
+                calendar_event_names=CALENDAR_EVENT_NAMES,
+                target_class_types=TARGET_CLASS_TYPES,
+                now=now,
+            )
+
+    store.mark_success.assert_not_called()
+
+
+def test_sync_calendar_unenrolls_mapped_class_without_calendar_event() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    enrolled = _class(
+        user_is_enrolled=True,
+        enroll_url=None,
+        unenroll_url=(
+            "https://www.regybox.pt/app/app_nova/php/aulas/cancela_aula.php?"
+            "id_aula=63049&data=2026-06-18&x=0e0e5e2b0fed2e699ba91b3d6506"
+        ),
+    )
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[enrolled]),
+    ):
+        calendar_cls.return_value.interval.return_value = []
+        result = sync_calendar(
+            store=MagicMock(),
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+        )
+
+    enrolled.unenroll.assert_called_once_with()
+    assert result.unenrolled == 1
+
+
+def test_sync_calendar_leaves_unmapped_enrolled_class_alone() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    yoga = _class(name="Yoga", user_is_enrolled=True, enroll_url=None)
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[yoga]),
+    ):
+        calendar_cls.return_value.interval.return_value = []
+        result = sync_calendar(
+            store=MagicMock(),
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+        )
+
+    yoga.unenroll.assert_not_called()
+    assert result.unenrolled == 0
+
+
+def test_sync_calendar_skips_not_open_class_outside_enroll_window() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    event = _CalendarEvent("Crossfit", datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE))
+    wod = _class(is_open=False, time_to_enroll=1801)
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[wod]),
+    ):
+        calendar_cls.return_value.interval.return_value = [event]
+        result = sync_calendar(
+            store=MagicMock(),
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+        )
+
+    wod.enroll.assert_not_called()
+    assert result.skipped_not_ready == 1
+
+
+def test_sync_calendar_skips_open_class_without_enroll_url() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    event = _CalendarEvent("Crossfit", datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE))
+    wod = _class(enroll_url=None)
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[wod]),
+    ):
+        calendar_cls.return_value.interval.return_value = [event]
+        result = sync_calendar(
+            store=MagicMock(),
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+        )
+
+    wod.enroll.assert_not_called()
+    assert result.skipped_not_ready == 1
+
+
+def test_sync_calendar_skips_when_calendar_event_has_no_matching_class() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    event = _CalendarEvent("Crossfit", datetime.datetime(2026, 6, 18, 8, 30, tzinfo=TIMEZONE))
+    wod = _class(start="06:30")
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[wod]),
+    ):
+        calendar_cls.return_value.interval.return_value = [event]
+        result = sync_calendar(
+            store=MagicMock(),
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+        )
+
+    wod.enroll.assert_not_called()
+    assert result.calendar_events == 1
+    assert result.enrolled == 0
+
+
+def test_sync_calendar_skips_already_enrolled_matching_calendar_class() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    event = _CalendarEvent("Crossfit", datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE))
+    wod = _class(user_is_enrolled=True)
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[wod]),
+    ):
+        calendar_cls.return_value.interval.return_value = [event]
+        result = sync_calendar(
+            store=MagicMock(),
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+        )
+
+    wod.enroll.assert_not_called()
+    wod.unenroll.assert_not_called()
+    assert result.enrolled == 0
+    assert result.unenrolled == 0
+
+
+def test_sync_calendar_ignores_unmapped_blank_and_all_day_events() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    naive_when = datetime.datetime.combine(datetime.date(2026, 6, 18), datetime.time(6, 30))
+    events = [
+        _CalendarEvent(None, datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE)),
+        _CalendarEvent("Yoga", datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE)),
+        _CalendarEvent("Crossfit", datetime.date(2026, 6, 18)),
+        _CalendarEvent("Crossfit", naive_when),
+    ]
+    wod = _class()
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[wod]),
+    ):
+        calendar_cls.return_value.interval.return_value = events
+        result = sync_calendar(
+            store=MagicMock(seen=MagicMock(return_value=False)),
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+        )
+
+    assert result.calendar_events == 1
+    assert result.enrolled == 1
+
+
+def test_sync_calendar_rejects_non_positive_options() -> None:
+    with pytest.raises(ValueError, match="lookahead-days"):
+        sync_calendar(
+            store=MagicMock(),
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            lookahead_days=0,
+        )
+    with pytest.raises(ValueError, match="enroll-window-minutes"):
+        sync_calendar(
+            store=MagicMock(),
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            enroll_window_minutes=0,
+        )
+
+
+def test_sync_calendar_requires_configured_calendar() -> None:
+    with patch("regybox.sync.Calendar") as calendar_cls:
+        calendar_cls.return_value.calendar = None
+        with pytest.raises(ValueError, match="CALENDAR_URL"):
+            sync_calendar(
+                store=MagicMock(),
+                calendar_event_names=CALENDAR_EVENT_NAMES,
+                target_class_types=TARGET_CLASS_TYPES,
+            )
+
+
+def test_sync_calendar_dry_run_does_not_mutate() -> None:
+    now = datetime.datetime(2026, 6, 17, 17, 0, tzinfo=TIMEZONE)
+    event = _CalendarEvent("Crossfit", datetime.datetime(2026, 6, 18, 6, 30, tzinfo=TIMEZONE))
+    wod = _class()
+    enrolled = _class(user_is_enrolled=True, start="07:30", enroll_url=None)
+    store = MagicMock()
+    store.seen.return_value = False
+
+    with (
+        patch("regybox.sync.Calendar") as calendar_cls,
+        patch("regybox.sync.get_classes", return_value=[wod, enrolled]),
+    ):
+        calendar_cls.return_value.interval.return_value = [event]
+        result = sync_calendar(
+            store=store,
+            calendar_event_names=CALENDAR_EVENT_NAMES,
+            target_class_types=TARGET_CLASS_TYPES,
+            now=now,
+            dry_run=True,
+        )
+
+    wod.enroll.assert_not_called()
+    enrolled.unenroll.assert_not_called()
+    store.mark_success.assert_not_called()
+    assert result.enrolled == 1
+    assert result.unenrolled == 1


### PR DESCRIPTION
- add calendar-driven sync mode with Cloudflare KV caching
- add workflow dispatch entrypoint for Cloudflare Workers
- document Cloudflare setup and sync configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added calendar-driven enrollment synchronization: automatically enroll in classes based on calendar events using the new `regybox-sync` command.
  * GitHub Actions workflow for manual calendar sync triggers with dry-run mode, customizable lookahead windows, and event-to-class filtering.

* **Documentation**
  * Comprehensive setup guide for calendar-driven sync integration with Cloudflare configuration and environment setup.

* **Tests**
  * Added test coverage for calendar sync functionality and CLI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->