### PR TITLE
fix: no-op unopened class operations

### DIFF
--- a/.github/workflows/class_operation.yml
+++ b/.github/workflows/class_operation.yml
@@ -46,7 +46,7 @@ jobs:
           class-type: ${{ inputs.class-type }}
           calendar-event-name: ${{ inputs.calendar-event-name }}
           timeout-seconds: 900
-          not-open-is-noop: false
+          not-open-is-noop: true
           cache-key: ${{ inputs.cache-key }}
           calendar-fingerprint: ${{ inputs.calendar-fingerprint }}
           cf-account-id: ${{ secrets.CF_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -303,8 +303,8 @@ before assuming the trigger is broken.
 The class operation workflow waits up to 15 minutes (`timeout-seconds: 900`) after it starts. That
 timeout pairs with the 73-hour lookahead: the Worker may dispatch slightly before the exact opening
 minute, and the GitHub Action has enough time to queue, start, and wait for Regybox enrollment to
-become available. The calendar-driven workflow keeps `not-open-is-noop` disabled so this wait is
-used instead of exiting immediately when enrollment is not open yet.
+become available. If Regybox still reports that enrollment is not open yet, the workflow exits as a
+no-op without sending email.
 
 #### 8. Test the Setup
 

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -38,7 +38,7 @@ def test_class_operation_workflow_exposes_dispatch_and_kv_inputs() -> None:
     assert "calendar-fingerprint:" in workflow_text
     assert "calendar-event-name: ${{ inputs.calendar-event-name }}" in workflow_text
     assert "timeout-seconds: 900" in workflow_text
-    assert "not-open-is-noop: false" in workflow_text
+    assert "not-open-is-noop: true" in workflow_text
     assert "cf-account-id: ${{ secrets.CF_ACCOUNT_ID }}" in workflow_text
     assert "cf-kv-namespace-id: ${{ secrets.CF_KV_NAMESPACE_ID }}" in workflow_text
     assert "cf-kv-api-token: ${{ secrets.CF_KV_API_TOKEN }}" in workflow_text


### PR DESCRIPTION
- treat unopened class operation dispatches as no-op
- update workflow metadata coverage for unopened enrollment
- document no-email behavior for unopened enrollment