### PR TITLE
fix: reduce repeated regybox enrollment alerts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -238,6 +238,22 @@ runs:
         body: ${{ env.EMAIL_BODY }}
         to: ${{ inputs.email-to }}
         from: ${{ inputs.email-from-name }} <${{ inputs.email-username }}>
+    - name: Cache delivered failure notification
+      if: >-
+        inputs.send-email != 'false' &&
+        env.SHOULD_SEND_EMAIL == 'true' &&
+        env.ENROLL_RESULT == 'failure' &&
+        env.CACHE_KEY != ''
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      env:
+        CACHE_KEY: ${{ env.CACHE_KEY }}
+        FAILURE_NOTIFICATION_FINGERPRINT: ${{ env.FAILURE_NOTIFICATION_FINGERPRINT }}
+        CF_ACCOUNT_ID: ${{ inputs.cf-account-id }}
+        CF_KV_NAMESPACE_ID: ${{ inputs.cf-kv-namespace-id }}
+        CF_KV_API_TOKEN: ${{ inputs.cf-kv-api-token }}
+        REGYBOX_RECORD_DELIVERED_FAILURE: "true"
+      run: uv run python -m regybox.notifications
 branding:
   color: blue
   icon: clock

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,15 @@ runs:
         if [[ "${ENROLL_OUTCOME}" == "success" ]]; then
           if grep -q "REGYBOX_RESULT=noop" "${ENROLL_LOG_PATH}"; then
             result=noop
-            if ! grep -Eq "Enrollment (is not open|did not open)" "${ENROLL_LOG_PATH}"; then
+            if grep -q "REGYBOX_CACHE_STATE=not_open" "${ENROLL_LOG_PATH}"; then
+              cache_should_update=true
+              cache_line="$(grep "REGYBOX_CACHE_STATE=not_open" "${ENROLL_LOG_PATH}" | tail -n 1)"
+              echo "CACHE_STATE=not_open" >> "$GITHUB_ENV"
+              enrollment_opens_at="$(sed -n 's/.*enrollment_opens_at=\([^ ]*\).*/\1/p' <<< "${cache_line}")"
+              last_checked_at="$(sed -n 's/.*last_checked_at=\([^ ]*\).*/\1/p' <<< "${cache_line}")"
+              echo "ENROLLMENT_OPENS_AT=${enrollment_opens_at}" >> "$GITHUB_ENV"
+              echo "LAST_CHECKED_AT=${last_checked_at}" >> "$GITHUB_ENV"
+            elif ! grep -Eq "Enrollment (is not open|did not open)" "${ENROLL_LOG_PATH}"; then
               cache_should_update=true
             fi
           else
@@ -178,12 +186,15 @@ runs:
         CF_KV_NAMESPACE_ID: ${{ inputs.cf-kv-namespace-id }}
         CF_KV_API_TOKEN: ${{ inputs.cf-kv-api-token }}
         CACHE_KEY: ${{ env.CACHE_KEY }}
+        CACHE_STATE: ${{ env.CACHE_STATE }}
         REGYBOX_OPERATION: ${{ env.REGYBOX_OPERATION }}
         CLASS_DATE: ${{ env.CLASS_DATE }}
         CLASS_TIME: ${{ env.CLASS_TIME }}
         CLASS_TYPE: ${{ env.CLASS_TYPE }}
         CALENDAR_EVENT_NAME: ${{ env.CALENDAR_EVENT_NAME }}
         CALENDAR_FINGERPRINT: ${{ env.CALENDAR_FINGERPRINT }}
+        ENROLLMENT_OPENS_AT: ${{ env.ENROLLMENT_OPENS_AT }}
+        LAST_CHECKED_AT: ${{ env.LAST_CHECKED_AT }}
       run: uv run python -m regybox.cloudflare_kv
     - name: Compose confirmation email
       if: always() && inputs.send-email != 'false'
@@ -197,6 +208,10 @@ runs:
         REGYBOX_OPERATION: ${{ env.REGYBOX_OPERATION }}
         ENROLL_LOG_PATH: ${{ env.ENROLL_LOG_PATH }}
         ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        CACHE_KEY: ${{ env.CACHE_KEY }}
+        CF_ACCOUNT_ID: ${{ inputs.cf-account-id }}
+        CF_KV_NAMESPACE_ID: ${{ inputs.cf-kv-namespace-id }}
+        CF_KV_API_TOKEN: ${{ inputs.cf-kv-api-token }}
       run: uv run python -m regybox.notifications
     - name: Validate email inputs
       if: always() && inputs.send-email != 'false' && env.SHOULD_SEND_EMAIL == 'true'

--- a/cloudflare/regybox-scheduler/test/worker.test.js
+++ b/cloudflare/regybox-scheduler/test/worker.test.js
@@ -179,6 +179,147 @@ test("existing KV entry with matching calendar event skips dispatch", async () =
   assert.deepEqual(plan.dispatches, []);
 });
 
+test("not-open KV entry skips dispatch when opening is far away and recently checked", async () => {
+  const key = "regybox:v1:calendar:one-class:2026-06-18T05:30:00.000Z";
+  const kv = makeKv(
+    new Map([
+      [
+        key,
+        JSON.stringify({
+          state: "not_open",
+          classDate: "2026-06-18",
+          classTime: "06:30",
+          classType: "WOD",
+          enrollmentOpensAt: "2026-06-18T05:00:00.000Z",
+          lastCheckedAt: "2026-06-18T00:00:00.000Z",
+        }),
+      ],
+    ]),
+  );
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:one-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260618T053000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const plan = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: ics,
+    now: new Date("2026-06-18T00:30:00Z"),
+  });
+
+  assert.deepEqual(plan.dispatches, []);
+});
+
+test("not-open KV entry dispatches when enrollment opens within 60 minutes", async () => {
+  const key = "regybox:v1:calendar:one-class:2026-06-18T05:30:00.000Z";
+  const kv = makeKv(
+    new Map([
+      [
+        key,
+        JSON.stringify({
+          state: "not_open",
+          classDate: "2026-06-18",
+          classTime: "06:30",
+          classType: "WOD",
+          enrollmentOpensAt: "2026-06-18T01:20:00.000Z",
+          lastCheckedAt: "2026-06-18T00:00:00.000Z",
+        }),
+      ],
+    ]),
+  );
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:one-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260618T053000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const plan = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: ics,
+    now: new Date("2026-06-18T00:30:00Z"),
+  });
+
+  assert.equal(plan.dispatches.length, 1);
+  assert.equal(plan.dispatches[0].operation, "enroll");
+});
+
+test("not-open KV entry dispatches when last check is over 24 hours old", async () => {
+  const key = "regybox:v1:calendar:one-class:2026-06-19T05:30:00.000Z";
+  const kv = makeKv(
+    new Map([
+      [
+        key,
+        JSON.stringify({
+          state: "not_open",
+          classDate: "2026-06-19",
+          classTime: "06:30",
+          classType: "WOD",
+          enrollmentOpensAt: "2026-06-19T05:00:00.000Z",
+          lastCheckedAt: "2026-06-17T00:00:00.000Z",
+        }),
+      ],
+    ]),
+  );
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:one-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260619T053000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const plan = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: ics,
+    now: new Date("2026-06-18T00:30:00Z"),
+  });
+
+  assert.equal(plan.dispatches.length, 1);
+  assert.equal(plan.dispatches[0].operation, "enroll");
+});
+
+test("stale not-open KV entries do not dispatch unenroll", async () => {
+  const key = "regybox:v1:calendar:old-class:2026-06-18T06:30:00.000Z";
+  const kv = makeKv(
+    new Map([
+      [
+        key,
+        JSON.stringify({
+          state: "not_open",
+          classDate: "2026-06-18",
+          classTime: "06:30",
+          classType: "WOD",
+          enrollmentOpensAt: "2026-06-18T05:00:00.000Z",
+          lastCheckedAt: "2026-06-18T00:00:00.000Z",
+        }),
+      ],
+    ]),
+  );
+
+  const plan = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: "BEGIN:VCALENDAR\r\nEND:VCALENDAR",
+    now: new Date("2026-06-18T00:30:00Z"),
+  });
+
+  assert.deepEqual(plan.dispatches, []);
+});
+
 test("stale enrolled KV entry dispatches unenroll", async () => {
   const key = "regybox:v1:calendar:old-class:2026-06-18T06:30:00.000Z";
   const kv = makeKv(

--- a/cloudflare/regybox-scheduler/test/worker.test.js
+++ b/cloudflare/regybox-scheduler/test/worker.test.js
@@ -254,6 +254,81 @@ test("not-open KV entry dispatches when enrollment opens within 60 minutes", asy
   assert.equal(plan.dispatches[0].operation, "enroll");
 });
 
+test("not-open KV entry dispatches when enrollment open time is missing", async () => {
+  const key = "regybox:v1:calendar:one-class:2026-06-18T05:30:00.000Z";
+  const kv = makeKv(
+    new Map([
+      [
+        key,
+        JSON.stringify({
+          state: "not_open",
+          classDate: "2026-06-18",
+          classTime: "06:30",
+          classType: "WOD",
+          lastCheckedAt: "2026-06-18T00:00:00.000Z",
+        }),
+      ],
+    ]),
+  );
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:one-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260618T053000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const plan = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: ics,
+    now: new Date("2026-06-18T00:30:00Z"),
+  });
+
+  assert.equal(plan.dispatches.length, 1);
+  assert.equal(plan.dispatches[0].operation, "enroll");
+});
+
+test("not-open KV entry dispatches when last check time is invalid", async () => {
+  const key = "regybox:v1:calendar:one-class:2026-06-18T05:30:00.000Z";
+  const kv = makeKv(
+    new Map([
+      [
+        key,
+        JSON.stringify({
+          state: "not_open",
+          classDate: "2026-06-18",
+          classTime: "06:30",
+          classType: "WOD",
+          enrollmentOpensAt: "2026-06-18T05:00:00.000Z",
+          lastCheckedAt: "not-a-date",
+        }),
+      ],
+    ]),
+  );
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:one-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260618T053000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const plan = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: ics,
+    now: new Date("2026-06-18T00:30:00Z"),
+  });
+
+  assert.equal(plan.dispatches.length, 1);
+  assert.equal(plan.dispatches[0].operation, "enroll");
+});
+
 test("not-open KV entry dispatches when last check is over 24 hours old", async () => {
   const key = "regybox:v1:calendar:one-class:2026-06-19T05:30:00.000Z";
   const kv = makeKv(

--- a/cloudflare/regybox-scheduler/worker.js
+++ b/cloudflare/regybox-scheduler/worker.js
@@ -1,4 +1,6 @@
 const KV_PREFIX = "regybox:v1:calendar:";
+const NOT_OPEN_REFRESH_MS = 24 * 60 * 60 * 1000;
+const NOT_OPEN_DISPATCH_WINDOW_MS = 60 * 60 * 1000;
 
 export function normalizeList(value) {
   return String(value ?? "")
@@ -286,6 +288,29 @@ function cachedSlotKey(cached) {
   return classSlotKey(cached?.classDate, cached?.classTime, cached?.classType);
 }
 
+function parseOptionalDate(value) {
+  if (!value) {
+    return null;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function notOpenShouldDispatch(cached, now) {
+  if (cached?.state !== "not_open") {
+    return true;
+  }
+  const enrollmentOpensAt = parseOptionalDate(cached.enrollmentOpensAt);
+  const lastCheckedAt = parseOptionalDate(cached.lastCheckedAt);
+  if (!enrollmentOpensAt || !lastCheckedAt) {
+    return true;
+  }
+  if (enrollmentOpensAt.getTime() - now.getTime() <= NOT_OPEN_DISPATCH_WINDOW_MS) {
+    return true;
+  }
+  return now.getTime() - lastCheckedAt.getTime() >= NOT_OPEN_REFRESH_MS;
+}
+
 function dispatchPayload({ env, operation, event, cacheKey, cached }) {
   const classDate = event?.classDate ?? cached.classDate;
   const classTime = event?.classTime ?? cached.classTime;
@@ -339,7 +364,7 @@ export async function buildPlan({ env, kv, icsText, now = new Date() }) {
   for (const [event, cached] of eventCacheEntries) {
     const slotKey = eventSlotKey(event, env);
     if (
-      (!cached || cached.state !== "enrolled") &&
+      (!cached || (cached.state !== "enrolled" && notOpenShouldDispatch(cached, now))) &&
       !enrolledSlots.has(slotKey) &&
       !plannedEnrollmentSlots.has(slotKey)
     ) {

--- a/src/regybox/classes.py
+++ b/src/regybox/classes.py
@@ -273,12 +273,12 @@ class Class:
         """
         if self.user_is_enrolled:
             raise UserAlreadyEnrolledError
+        if self.is_overbooked:
+            raise ClassIsOverbookedError
         if self.enroll_url is None:
             raise ValueError("Enroll URL is not set")
         if not self.is_open:
             raise ClassNotOpenError
-        if self.is_overbooked:
-            raise ClassIsOverbookedError
 
         res_html: str = get_url_html(self.enroll_url)
         LOGGER.debug(f"Enrolled at {self.enroll_url} with response: '{res_html}'")

--- a/src/regybox/cloudflare_kv.py
+++ b/src/regybox/cloudflare_kv.py
@@ -56,6 +56,8 @@ class SchedulerState:
     class_type: str
     calendar_event_name: str
     calendar_fingerprint: str
+    enrollment_opens_at: str = ""
+    last_checked_at: str = ""
 
 
 def write_state(
@@ -72,6 +74,10 @@ def write_state(
         "calendarEventName": scheduler_state.calendar_event_name,
         "calendarFingerprint": scheduler_state.calendar_fingerprint,
     }
+    if scheduler_state.enrollment_opens_at:
+        payload["enrollmentOpensAt"] = scheduler_state.enrollment_opens_at
+    if scheduler_state.last_checked_at:
+        payload["lastCheckedAt"] = scheduler_state.last_checked_at
     response = requests.put(
         (
             "https://api.cloudflare.com/client/v4/accounts/"
@@ -98,7 +104,10 @@ def main() -> None:
     operation = os.environ.get("REGYBOX_OPERATION", "enroll").strip()
     if operation not in {"enroll", "unenroll"}:
         raise ValueError("REGYBOX_OPERATION must be either 'enroll' or 'unenroll'.")
-    state = "unenrolled" if operation == "unenroll" else "enrolled"
+    cache_state = os.environ.get("CACHE_STATE", "").strip()
+    if cache_state and cache_state not in {"enrolled", "unenrolled", "not_open"}:
+        raise ValueError("CACHE_STATE must be enrolled, unenrolled, or not_open.")
+    state = cache_state or ("unenrolled" if operation == "unenroll" else "enrolled")
     try:
         write_state(
             config=CloudflareKVConfig.from_env(),
@@ -110,6 +119,8 @@ def main() -> None:
                 class_type=os.environ.get("CLASS_TYPE", "").strip(),
                 calendar_event_name=os.environ.get("CALENDAR_EVENT_NAME", "").strip(),
                 calendar_fingerprint=os.environ.get("CALENDAR_FINGERPRINT", "").strip(),
+                enrollment_opens_at=os.environ.get("ENROLLMENT_OPENS_AT", "").strip(),
+                last_checked_at=os.environ.get("LAST_CHECKED_AT", "").strip(),
             ),
         )
     except (ValueError, requests.RequestException) as exc:

--- a/src/regybox/connection.py
+++ b/src/regybox/connection.py
@@ -17,6 +17,10 @@ from regybox.exceptions import RegyboxLoginError
 from regybox.utils.singleton import Singleton
 
 DOMAIN: str = "https://www.regybox.pt/app/app_nova/"
+DEFAULT_TIMEOUT_SECONDS: int = 15
+RETRY_TOTAL: int = 4
+RETRY_BACKOFF_FACTOR: float = 0.75
+RETRY_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
 HEADERS: dict[str, str] = {
     "Accept": "text/html, */*; q=0.01",
     "Accept-Encoding": "gzip, deflate, br",
@@ -53,7 +57,16 @@ class RegyboxSession(requests.Session, metaclass=Singleton):
     def __init__(self, *, user: str = REGYBOX_USER) -> None:
         """Initialize a new instance of the RegyboxSession class."""
         super().__init__()
-        adapter: HTTPAdapter = HTTPAdapter(max_retries=Retry(connect=10, backoff_factor=0.5))
+        retry_policy = Retry(
+            total=RETRY_TOTAL,
+            connect=RETRY_TOTAL,
+            read=RETRY_TOTAL,
+            status=RETRY_TOTAL,
+            backoff_factor=RETRY_BACKOFF_FACTOR,
+            status_forcelist=RETRY_STATUS_CODES,
+            allowed_methods=frozenset({"HEAD", "GET", "POST", "PUT", "DELETE", "OPTIONS"}),
+        )
+        adapter: HTTPAdapter = HTTPAdapter(max_retries=retry_policy)
         self.mount("http://", adapter)
         self.mount("https://", adapter)
         self.set_session(user=user)  # only called once since this is a singleton
@@ -68,6 +81,7 @@ class RegyboxSession(requests.Session, metaclass=Singleton):
             urljoin(DOMAIN, "set_session.php"),
             headers=HEADERS,
             params=self.get_session_params(user=user),
+            timeout=DEFAULT_TIMEOUT_SECONDS,
         ).raise_for_status()
 
     @staticmethod
@@ -102,7 +116,7 @@ def get_url_html(url: str, *, params: dict[str, str] | None = None) -> str:
     """
     query_params: dict[str, str] = params if params is not None else {}
     res: requests.models.Response = RegyboxSession().get(
-        url, headers=HEADERS, params=query_params, timeout=10
+        url, headers=HEADERS, params=query_params, timeout=DEFAULT_TIMEOUT_SECONDS
     )
     res.raise_for_status()
     if re.findall(r"app/app_nova/login.php", res.text):

--- a/src/regybox/notifications.py
+++ b/src/regybox/notifications.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import json
 import os
 import re
+import urllib.parse
 from pathlib import Path
 from typing import cast
 
+import requests
+
+from regybox.cloudflare_kv import KV_TTL_SECONDS, CloudflareKVConfig
 from regybox.exceptions import REGYBOX_USER_ERROR_PREFIX, UserErrorPayload
 
 MAX_APPENDIX_LINES: int = 12
+HTTP_NOT_FOUND: int = 404
 
 
 def read_log_text(path: str | None) -> str:
@@ -232,6 +237,127 @@ def _fallback_user_payload(signal: str | None) -> UserErrorPayload:
     }
 
 
+def build_failure_notification_fingerprint(
+    *, enroll_result: str, operation: str, log_text: str
+) -> str:
+    """Build a stable identity for the current failure notification.
+
+    Returns:
+        A stable fingerprint for failure results, otherwise an empty string.
+    """
+    normalized_result = enroll_result.strip().lower()
+    normalized_operation = operation.strip().lower() or "enroll"
+    if normalized_result != "failure":
+        return ""
+
+    payload = extract_user_error_payload(log_text)
+    if payload is None:
+        payload = _fallback_user_payload(extract_error_signal(log_text))
+    return f"failure:{normalized_operation}:{payload['error_code']}:{payload['user_title']}"
+
+
+def should_send_email_for_state(
+    *,
+    enroll_result: str,
+    current_failure_fingerprint: str,
+    cached_failure_fingerprint: str | None,
+) -> bool:
+    """Return whether email should send after cached failure comparison.
+
+    Returns:
+        Whether the current result should send an email.
+    """
+    normalized_result = enroll_result.strip().lower()
+    if normalized_result != "failure":
+        return should_send_email(enroll_result)
+    return bool(current_failure_fingerprint) and (
+        cached_failure_fingerprint != current_failure_fingerprint
+    )
+
+
+def _kv_value_url(*, config: CloudflareKVConfig, cache_key: str) -> str:
+    return (
+        "https://api.cloudflare.com/client/v4/accounts/"
+        f"{config.account_id}/storage/kv/namespaces/{config.namespace_id}/values/"
+        f"{urllib.parse.quote(cache_key, safe='')}"
+    )
+
+
+def read_kv_json(*, config: CloudflareKVConfig, cache_key: str) -> dict[str, object]:
+    """Read an existing Cloudflare KV JSON value.
+
+    Returns:
+        The parsed JSON dictionary, or an empty dictionary when missing.
+    """
+    response = requests.get(
+        _kv_value_url(config=config, cache_key=cache_key),
+        headers={"Authorization": f"Bearer {config.api_token}"},
+        timeout=15,
+    )
+    if response.status_code == HTTP_NOT_FOUND:
+        return {}
+    response.raise_for_status()
+    parsed = _try_parse_json(response.text)
+    return parsed or {}
+
+
+def write_kv_json(
+    *, config: CloudflareKVConfig, cache_key: str, payload: dict[str, object]
+) -> None:
+    """Write a Cloudflare KV JSON value."""
+    response = requests.put(
+        _kv_value_url(config=config, cache_key=cache_key),
+        headers={"Authorization": f"Bearer {config.api_token}"},
+        params={"expiration_ttl": str(KV_TTL_SECONDS)},
+        data=json.dumps(payload, sort_keys=True),
+        timeout=15,
+    )
+    response.raise_for_status()
+
+
+def _should_send_email_with_cache(
+    *,
+    enroll_result: str,
+    operation: str,
+    log_text: str,
+    cache_key: str,
+) -> bool:
+    """Apply repeated-failure suppression when KV cache is configured.
+
+    Returns:
+        Whether the current result should send an email.
+    """
+    if enroll_result.strip().lower() != "failure" or not cache_key:
+        return should_send_email(enroll_result)
+
+    current_fingerprint = build_failure_notification_fingerprint(
+        enroll_result=enroll_result,
+        operation=operation,
+        log_text=log_text,
+    )
+    try:
+        config = CloudflareKVConfig.from_env()
+        cached_payload = read_kv_json(config=config, cache_key=cache_key)
+    except (ValueError, requests.RequestException):
+        return should_send_email(enroll_result)
+
+    cached_fingerprint = cached_payload.get("failureNotificationFingerprint")
+    cached_fingerprint_str = cached_fingerprint if isinstance(cached_fingerprint, str) else None
+    send_email = should_send_email_for_state(
+        enroll_result=enroll_result,
+        current_failure_fingerprint=current_fingerprint,
+        cached_failure_fingerprint=cached_fingerprint_str,
+    )
+    if not send_email:
+        return False
+    cached_payload["failureNotificationFingerprint"] = current_fingerprint
+    try:
+        write_kv_json(config=config, cache_key=cache_key, payload=cached_payload)
+    except requests.RequestException:
+        return should_send_email(enroll_result)
+    return True
+
+
 def _trim_appendix(text: str) -> str:
     """Limit technical appendix size for readability.
 
@@ -371,18 +497,26 @@ def main() -> None:
         f"{os.environ.get('CLASS_TIME', 'Unknown time')}"
     )
     log_text: str = read_log_text(os.environ.get("ENROLL_LOG_PATH"))
+    enroll_result = os.environ.get("ENROLL_RESULT", "failure")
+    operation = os.environ.get("REGYBOX_OPERATION", "enroll")
     subject, body = build_email_content(
-        enroll_result=os.environ.get("ENROLL_RESULT", "failure"),
+        enroll_result=enroll_result,
         class_summary=class_summary,
         run_url=os.environ.get("ACTION_RUN_URL"),
         log_text=log_text,
-        operation=os.environ.get("REGYBOX_OPERATION", "enroll"),
+        operation=operation,
+    )
+    send_email = _should_send_email_with_cache(
+        enroll_result=enroll_result,
+        operation=operation,
+        log_text=log_text,
+        cache_key=os.environ.get("CACHE_KEY", "").strip(),
     )
     write_multiline_env(name="EMAIL_SUBJECT", value=subject, github_env_path=github_env_path)
     write_multiline_env(name="EMAIL_BODY", value=body, github_env_path=github_env_path)
     write_multiline_env(
         name="SHOULD_SEND_EMAIL",
-        value="true" if should_send_email(os.environ.get("ENROLL_RESULT", "failure")) else "false",
+        value="true" if send_email else "false",
         github_env_path=github_env_path,
     )
 

--- a/src/regybox/notifications.py
+++ b/src/regybox/notifications.py
@@ -343,19 +343,32 @@ def _should_send_email_with_cache(
 
     cached_fingerprint = cached_payload.get("failureNotificationFingerprint")
     cached_fingerprint_str = cached_fingerprint if isinstance(cached_fingerprint, str) else None
-    send_email = should_send_email_for_state(
+    return should_send_email_for_state(
         enroll_result=enroll_result,
         current_failure_fingerprint=current_fingerprint,
         cached_failure_fingerprint=cached_fingerprint_str,
     )
-    if not send_email:
-        return False
-    cached_payload["failureNotificationFingerprint"] = current_fingerprint
+
+
+def record_delivered_failure_notification(*, cache_key: str, fingerprint: str) -> None:
+    """Record a failure notification after email delivery."""
+    if not cache_key or not fingerprint:
+        return
+    config = CloudflareKVConfig.from_env()
+    cached_payload = read_kv_json(config=config, cache_key=cache_key)
+    cached_payload["failureNotificationFingerprint"] = fingerprint
+    write_kv_json(config=config, cache_key=cache_key, payload=cached_payload)
+
+
+def record_delivered_failure_notification_from_env() -> None:
+    """Record delivered failure notification state from action environment."""
     try:
-        write_kv_json(config=config, cache_key=cache_key, payload=cached_payload)
-    except requests.RequestException:
-        return should_send_email(enroll_result)
-    return True
+        record_delivered_failure_notification(
+            cache_key=os.environ.get("CACHE_KEY", "").strip(),
+            fingerprint=os.environ.get("FAILURE_NOTIFICATION_FINGERPRINT", "").strip(),
+        )
+    except (ValueError, requests.RequestException) as exc:
+        print(f"Warning: Cloudflare KV failure notification cache update failed: {exc}")
 
 
 def _trim_appendix(text: str) -> str:
@@ -487,6 +500,10 @@ def main() -> None:
     Raises:
         RuntimeError: If ``GITHUB_ENV`` is not available in the environment.
     """
+    if os.environ.get("REGYBOX_RECORD_DELIVERED_FAILURE", "").strip().lower() == "true":
+        record_delivered_failure_notification_from_env()
+        return
+
     github_env_path: str | None = os.environ.get("GITHUB_ENV")
     if not github_env_path:
         raise RuntimeError("GITHUB_ENV is required to compose email notification content.")
@@ -512,8 +529,18 @@ def main() -> None:
         log_text=log_text,
         cache_key=os.environ.get("CACHE_KEY", "").strip(),
     )
+    failure_fingerprint = build_failure_notification_fingerprint(
+        enroll_result=enroll_result,
+        operation=operation,
+        log_text=log_text,
+    )
     write_multiline_env(name="EMAIL_SUBJECT", value=subject, github_env_path=github_env_path)
     write_multiline_env(name="EMAIL_BODY", value=body, github_env_path=github_env_path)
+    write_multiline_env(
+        name="FAILURE_NOTIFICATION_FINGERPRINT",
+        value=failure_fingerprint,
+        github_env_path=github_env_path,
+    )
     write_multiline_env(
         name="SHOULD_SEND_EMAIL",
         value="true" if send_email else "false",

--- a/src/regybox/regybox.py
+++ b/src/regybox/regybox.py
@@ -200,6 +200,44 @@ def _pick_unenroll_class(
     )
 
 
+def _enroll_selected_class(
+    *,
+    class_: Class,
+    resolved_class_type: str,
+    date: datetime.date,
+    class_time: str,
+) -> OperationResult:
+    if _class_bool(class_, "user_is_enrolled"):
+        LOGGER.info("Already enrolled in class")
+        return _operation_result(
+            operation="enroll",
+            status="noop",
+            class_type=resolved_class_type,
+        )
+    if _class_bool(class_, "is_overbooked"):
+        raise ClassIsOverbookedError
+    if _class_bool(class_, "is_full") and getattr(class_, "enroll_url", None):
+        LOGGER.info(
+            f"{resolved_class_type} on {date.isoformat()} at {class_time} is full; attempting"
+            " waitlist enrollment"
+        )
+    try:
+        class_.enroll()
+    except UserAlreadyEnrolledError:
+        LOGGER.info("Already enrolled in class")
+        return _operation_result(
+            operation="enroll",
+            status="noop",
+            class_type=resolved_class_type,
+        )
+    LOGGER.info(f"Runtime: {(datetime.datetime.now(TIMEZONE) - START).total_seconds():.3f}")
+    return _operation_result(
+        operation="enroll",
+        status="success",
+        class_type=resolved_class_type,
+    )
+
+
 def _wait_for_enrollable_class(
     *,
     date: datetime.date,
@@ -300,7 +338,6 @@ def main(
 
     Raises:
         ValueError: If the class type input is empty.
-        ClassIsOverbookedError: If the class and waitlist are already full.
     """
     options = operation_options or OperationOptions()
     class_time = class_time.zfill(5)  # needs leading zeros
@@ -361,27 +398,11 @@ def main(
         LOGGER.info(
             f"Attempting to enroll in {resolved_class_type} on {date.isoformat()} at {class_time}"
         )
-    if _class_bool(class_, "is_overbooked"):
-        raise ClassIsOverbookedError
-    if _class_bool(class_, "is_full") and getattr(class_, "enroll_url", None):
-        LOGGER.info(
-            f"{resolved_class_type} on {date.isoformat()} at {class_time} is full; attempting"
-            " waitlist enrollment"
-        )
-    try:
-        class_.enroll()
-    except UserAlreadyEnrolledError:
-        LOGGER.info("Already enrolled in class")
-        return _operation_result(
-            operation="enroll",
-            status="noop",
-            class_type=resolved_class_type,
-        )
-    LOGGER.info(f"Runtime: {(datetime.datetime.now(TIMEZONE) - START).total_seconds():.3f}")
-    return _operation_result(
-        operation="enroll",
-        status="success",
-        class_type=resolved_class_type,
+    return _enroll_selected_class(
+        class_=class_,
+        resolved_class_type=resolved_class_type,
+        date=date,
+        class_time=class_time,
     )
 
 

--- a/src/regybox/regybox.py
+++ b/src/regybox/regybox.py
@@ -15,6 +15,7 @@ from regybox.cal import check_cal
 from regybox.classes import Class, get_classes, pick_class
 from regybox.common import LOGGER, TIMEZONE
 from regybox.exceptions import (
+    ClassIsOverbookedError,
     ClassNotFoundError,
     ClassNotOpenError,
     RegyboxTimeoutError,
@@ -108,11 +109,22 @@ def _unenroll_class(class_: Class, resolved_class_type: str) -> OperationResult:
 
 
 def _closed_enrollment_result(
-    *, options: OperationOptions, resolved_class_type: str
+    *,
+    options: OperationOptions,
+    resolved_class_type: str,
+    time_to_enroll: int | None,
 ) -> OperationResult | None:
     if not options.not_open_is_noop:
         return None
     LOGGER.info("Enrollment is not open; returning no-op result")
+    if time_to_enroll is not None:
+        last_checked_at = datetime.datetime.now(TIMEZONE)
+        enrollment_opens_at = last_checked_at + datetime.timedelta(seconds=time_to_enroll)
+        LOGGER.info(
+            "REGYBOX_CACHE_STATE=not_open "
+            f"enrollment_opens_at={enrollment_opens_at.isoformat()} "
+            f"last_checked_at={last_checked_at.isoformat()}"
+        )
     return _operation_result(
         operation="enroll",
         status="noop",
@@ -123,6 +135,11 @@ def _closed_enrollment_result(
 def _resolved_class_type(class_: Class, fallback: str) -> str:
     raw_name = getattr(class_, "name", fallback)
     return raw_name if isinstance(raw_name, str) else fallback
+
+
+def _class_bool(class_: Class, attr: str) -> bool:
+    value = getattr(class_, attr, False)
+    return value if isinstance(value, bool) else False
 
 
 def _pick_requested_class(
@@ -207,6 +224,7 @@ def _wait_for_enrollable_class(
         closed_result = _closed_enrollment_result(
             options=options,
             resolved_class_type=resolved_class_type,
+            time_to_enroll=picked.time_to_enroll,
         )
         if closed_result is not None:
             return closed_result
@@ -282,6 +300,7 @@ def main(
 
     Raises:
         ValueError: If the class type input is empty.
+        ClassIsOverbookedError: If the class and waitlist are already full.
     """
     options = operation_options or OperationOptions()
     class_time = class_time.zfill(5)  # needs leading zeros
@@ -308,6 +327,9 @@ def main(
         )
 
     if options.operation == "unenroll":
+        LOGGER.info(
+            f"Attempting to unenroll from {class_types[0]} on {date.isoformat()} at {class_time}"
+        )
         picked = _pick_unenroll_class(
             date=date,
             class_time=class_time,
@@ -315,8 +337,15 @@ def main(
         )
         if isinstance(picked, OperationResult):
             return picked
-        return _unenroll_class(picked, _resolved_class_type(picked, class_types[0]))
+        resolved_class_type = _resolved_class_type(picked, class_types[0])
+        if resolved_class_type != class_types[0]:
+            LOGGER.info(
+                f"Attempting to unenroll from {resolved_class_type} on {date.isoformat()} at"
+                f" {class_time}"
+            )
+        return _unenroll_class(picked, resolved_class_type)
 
+    LOGGER.info(f"Attempting to enroll in {class_types[0]} on {date.isoformat()} at {class_time}")
     picked = _wait_for_enrollable_class(
         date=date,
         class_time=class_time,
@@ -328,6 +357,17 @@ def main(
         return picked
     class_ = picked
     resolved_class_type = _resolved_class_type(class_, class_types[0])
+    if resolved_class_type != class_types[0]:
+        LOGGER.info(
+            f"Attempting to enroll in {resolved_class_type} on {date.isoformat()} at {class_time}"
+        )
+    if _class_bool(class_, "is_overbooked"):
+        raise ClassIsOverbookedError
+    if _class_bool(class_, "is_full") and getattr(class_, "enroll_url", None):
+        LOGGER.info(
+            f"{resolved_class_type} on {date.isoformat()} at {class_time} is full; attempting"
+            " waitlist enrollment"
+        )
     try:
         class_.enroll()
     except UserAlreadyEnrolledError:

--- a/tests/test_cloudflare_kv.py
+++ b/tests/test_cloudflare_kv.py
@@ -89,6 +89,34 @@ def test_write_state_sends_ttl_and_payload() -> None:
     response.raise_for_status.assert_called_once()
 
 
+def test_write_state_includes_not_open_metadata() -> None:
+    response = Mock()
+    with patch("regybox.cloudflare_kv.requests.put", return_value=response) as put:
+        write_state(
+            config=CloudflareKVConfig(
+                account_id="account",
+                namespace_id="namespace",
+                api_token=FAKE_CREDENTIAL,
+            ),
+            scheduler_state=SchedulerState(
+                cache_key="regybox:v1:key",
+                state="not_open",
+                class_date="2026-06-18",
+                class_time="06:30",
+                class_type="WOD",
+                calendar_event_name="Crossfit",
+                calendar_fingerprint="uid:start",
+                enrollment_opens_at="2026-06-18T05:30:00+00:00",
+                last_checked_at="2026-06-18T00:30:00+00:00",
+            ),
+        )
+
+    payload = json.loads(put.call_args.kwargs["data"])
+    assert payload["state"] == "not_open"
+    assert payload["enrollmentOpensAt"] == "2026-06-18T05:30:00+00:00"
+    assert payload["lastCheckedAt"] == "2026-06-18T00:30:00+00:00"
+
+
 def test_cloudflare_kv_main_skips_empty_cache_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CACHE_KEY", raising=False)
     with patch("regybox.cloudflare_kv.write_state") as mock_write_state:
@@ -125,11 +153,53 @@ def test_cloudflare_kv_main_writes_unenrolled_state(monkeypatch: pytest.MonkeyPa
     )
 
 
+def test_cloudflare_kv_main_writes_not_open_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CACHE_KEY", "regybox:v1:key")
+    monkeypatch.setenv("REGYBOX_OPERATION", "enroll")
+    monkeypatch.setenv("CACHE_STATE", "not_open")
+    monkeypatch.setenv("CLASS_DATE", "2026-06-18")
+    monkeypatch.setenv("CLASS_TIME", "06:30")
+    monkeypatch.setenv("CLASS_TYPE", "WOD")
+    monkeypatch.setenv("CALENDAR_EVENT_NAME", "Crossfit")
+    monkeypatch.setenv("CALENDAR_FINGERPRINT", "uid:start")
+    monkeypatch.setenv("ENROLLMENT_OPENS_AT", "2026-06-18T05:30:00+00:00")
+    monkeypatch.setenv("LAST_CHECKED_AT", "2026-06-18T00:30:00+00:00")
+    with (
+        patch("regybox.cloudflare_kv.CloudflareKVConfig.from_env") as from_env,
+        patch("regybox.cloudflare_kv.write_state") as mock_write_state,
+    ):
+        cloudflare_kv.main()
+
+    mock_write_state.assert_called_once_with(
+        config=from_env.return_value,
+        scheduler_state=SchedulerState(
+            cache_key="regybox:v1:key",
+            state="not_open",
+            class_date="2026-06-18",
+            class_time="06:30",
+            class_type="WOD",
+            calendar_event_name="Crossfit",
+            calendar_fingerprint="uid:start",
+            enrollment_opens_at="2026-06-18T05:30:00+00:00",
+            last_checked_at="2026-06-18T00:30:00+00:00",
+        ),
+    )
+
+
 def test_cloudflare_kv_main_rejects_unknown_operation(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CACHE_KEY", "regybox:v1:key")
     monkeypatch.setenv("REGYBOX_OPERATION", "pause")
 
     with pytest.raises(ValueError, match="REGYBOX_OPERATION"):
+        cloudflare_kv.main()
+
+
+def test_cloudflare_kv_main_rejects_unknown_cache_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CACHE_KEY", "regybox:v1:key")
+    monkeypatch.setenv("REGYBOX_OPERATION", "enroll")
+    monkeypatch.setenv("CACHE_STATE", "paused")
+
+    with pytest.raises(ValueError, match="CACHE_STATE"):
         cloudflare_kv.main()
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,6 +6,7 @@ import pytest
 import requests
 
 from regybox.connection import (
+    DEFAULT_TIMEOUT_SECONDS,
     HEADERS,
     RegyboxSession,
     get_classes_html,
@@ -50,6 +51,12 @@ def test_get_url_html_returns_text_on_success() -> None:
         mock_session_cls.return_value = mock_session
         result = get_url_html("https://example.com/page")
     assert result == "<html>classes</html>"
+    mock_session.get.assert_called_once_with(
+        "https://example.com/page",
+        headers=HEADERS,
+        params={},
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
 
 
 def test_get_classes_html_calls_get_url_html_with_params() -> None:
@@ -101,8 +108,35 @@ def test_regybox_session_set_session_calls_get(monkeypatch: pytest.MonkeyPatch) 
         "https://www.regybox.pt/app/app_nova/set_session.php",
         headers=HEADERS,
         params=RegyboxSession.get_session_params(user="testuser"),
+        timeout=DEFAULT_TIMEOUT_SECONDS,
     )
     response.raise_for_status.assert_called_once_with()
+
+
+def test_regybox_session_retry_adapter_retries_transient_statuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_session_init(_self: requests.Session) -> None:
+        return None
+
+    monkeypatch.setattr(requests.Session, "__init__", fake_session_init)
+    mount = MagicMock()
+    monkeypatch.setattr(RegyboxSession, "mount", mount)
+    monkeypatch.setattr(RegyboxSession, "set_session", MagicMock())
+    if RegyboxSession in Singleton._instances:
+        del Singleton._instances[RegyboxSession]
+    try:
+        RegyboxSession(user="testuser")
+    finally:
+        if RegyboxSession in Singleton._instances:
+            del Singleton._instances[RegyboxSession]
+
+    adapter = mount.call_args_list[1].args[1]
+    retries = adapter.max_retries
+    assert retries.total >= 3
+    assert retries.connect >= 3
+    assert retries.read >= 3
+    assert {429, 500, 502, 503, 504}.issubset(retries.status_forcelist)
 
 
 def test_regybox_session_get_session_params() -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -22,6 +22,7 @@ from regybox.notifications import (
     extract_user_error_payload,
     read_kv_json,
     read_log_text,
+    record_delivered_failure_notification,
     should_send_email,
     should_send_email_for_state,
     write_kv_json,
@@ -565,7 +566,7 @@ def test_notifications_main_suppresses_repeated_cached_failure(
     write_kv_json.assert_not_called()
 
 
-def test_notifications_main_sends_and_caches_changed_failure(
+def test_notifications_main_sends_changed_failure_without_caching_before_delivery(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     env_file = tmp_path / "env_failure"
@@ -589,7 +590,7 @@ def test_notifications_main_sends_and_caches_changed_failure(
     monkeypatch.setenv("ENROLL_LOG_PATH", str(log_path))
     monkeypatch.setenv("CACHE_KEY", "regybox:v1:key")
     with (
-        patch("regybox.notifications.CloudflareKVConfig.from_env") as from_env,
+        patch("regybox.notifications.CloudflareKVConfig.from_env"),
         patch(
             "regybox.notifications.read_kv_json",
             return_value={"failureNotificationFingerprint": "failure:enroll:login_error:old"},
@@ -601,12 +602,37 @@ def test_notifications_main_sends_and_caches_changed_failure(
     assert "SHOULD_SEND_EMAIL<<REGYBOX_SHOULD_SEND_EMAIL_EOF\ntrue" in env_file.read_text(
         encoding="utf-8"
     )
-    write_kv_json.assert_called_once()
-    assert write_kv_json.call_args.kwargs["config"] == from_env.return_value
-    assert write_kv_json.call_args.kwargs["cache_key"] == "regybox:v1:key"
+    env_text = env_file.read_text(encoding="utf-8")
     assert (
-        write_kv_json.call_args.kwargs["payload"]["failureNotificationFingerprint"]
-        == "failure:enroll:class_overbooked:Class and waitlist are full"
+        "FAILURE_NOTIFICATION_FINGERPRINT<<REGYBOX_FAILURE_NOTIFICATION_FINGERPRINT_EOF\n"
+        "failure:enroll:class_overbooked:Class and waitlist are full" in env_text
+    )
+    write_kv_json.assert_not_called()
+
+
+def test_record_delivered_failure_notification_caches_fingerprint() -> None:
+    with (
+        patch("regybox.notifications.CloudflareKVConfig.from_env") as from_env,
+        patch(
+            "regybox.notifications.read_kv_json",
+            return_value={"state": "not_open"},
+        ),
+        patch("regybox.notifications.write_kv_json") as write_kv_json,
+    ):
+        record_delivered_failure_notification(
+            cache_key="regybox:v1:key",
+            fingerprint="failure:enroll:class_overbooked:Class and waitlist are full",
+        )
+
+    write_kv_json.assert_called_once_with(
+        config=from_env.return_value,
+        cache_key="regybox:v1:key",
+        payload={
+            "state": "not_open",
+            "failureNotificationFingerprint": (
+                "failure:enroll:class_overbooked:Class and waitlist are full"
+            ),
+        },
     )
 
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -3,24 +3,32 @@
 import json
 import runpy
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from regybox import notifications as notifications_module
+from regybox.cloudflare_kv import KV_TTL_SECONDS, CloudflareKVConfig
 from regybox.exceptions import REGYBOX_USER_ERROR_PREFIX, UnplannedClassError
 from regybox.notifications import (
     _fallback_user_payload,
     _normalize_steps,
     _try_parse_json,
     build_email_content,
+    build_failure_notification_fingerprint,
     build_technical_appendix,
     extract_error_signal,
     extract_traceback,
     extract_user_error_payload,
+    read_kv_json,
     read_log_text,
     should_send_email,
+    should_send_email_for_state,
+    write_kv_json,
     write_multiline_env,
 )
+
+FAKE_CREDENTIAL = "not-a-real-value"
 
 
 def test_extract_user_error_payload() -> None:
@@ -165,6 +173,65 @@ def test_should_send_email_skips_noop_results() -> None:
     assert not should_send_email("noop")
     assert should_send_email("success")
     assert should_send_email("failure")
+
+
+def test_failure_notification_fingerprint_uses_structured_payload() -> None:
+    payload = {
+        "error_code": "class_overbooked",
+        "user_title": "Class and waitlist are full",
+        "user_message": "No spots are available.",
+        "user_next_steps": ["Retry later."],
+        "technical_message": "Class is overbooked",
+    }
+    log_text = f"ERROR {REGYBOX_USER_ERROR_PREFIX}{json.dumps(payload)}"
+
+    assert (
+        build_failure_notification_fingerprint(
+            enroll_result="failure",
+            operation="enroll",
+            log_text=log_text,
+        )
+        == "failure:enroll:class_overbooked:Class and waitlist are full"
+    )
+
+
+def test_failure_notification_fingerprint_empty_for_success() -> None:
+    assert not build_failure_notification_fingerprint(
+        enroll_result="success",
+        operation="enroll",
+        log_text="",
+    )
+
+
+def test_should_send_email_for_state_delegates_non_failures() -> None:
+    assert should_send_email_for_state(
+        enroll_result="success",
+        current_failure_fingerprint="",
+        cached_failure_fingerprint=None,
+    )
+    assert not should_send_email_for_state(
+        enroll_result="noop",
+        current_failure_fingerprint="",
+        cached_failure_fingerprint=None,
+    )
+
+
+def test_should_send_email_for_state_suppresses_repeated_failure() -> None:
+    fingerprint = "failure:enroll:class_overbooked:Class and waitlist are full"
+
+    assert not should_send_email_for_state(
+        enroll_result="failure",
+        current_failure_fingerprint=fingerprint,
+        cached_failure_fingerprint=fingerprint,
+    )
+
+
+def test_should_send_email_for_state_sends_different_failure() -> None:
+    assert should_send_email_for_state(
+        enroll_result="failure",
+        current_failure_fingerprint="failure:enroll:login_error:Unable to log in to Regybox",
+        cached_failure_fingerprint="failure:enroll:class_overbooked:Class and waitlist are full",
+    )
 
 
 def test_build_email_content_includes_calendar_event_name_for_unplanned_class() -> None:
@@ -403,3 +470,163 @@ def test_notifications_main_sets_should_send_email_env(
             f"SHOULD_SEND_EMAIL<<REGYBOX_SHOULD_SEND_EMAIL_EOF\n{expected}"
             in env_file.read_text(encoding="utf-8")
         )
+
+
+def test_read_kv_json_returns_empty_for_missing_value() -> None:
+    with patch("regybox.notifications.requests.get") as get:
+        response = get.return_value
+        response.status_code = 404
+        assert (
+            read_kv_json(
+                config=CloudflareKVConfig(
+                    account_id="account",
+                    namespace_id="namespace",
+                    api_token=FAKE_CREDENTIAL,
+                ),
+                cache_key="regybox:v1:key",
+            )
+            == {}
+        )
+
+
+def test_read_kv_json_parses_existing_value() -> None:
+    with patch("regybox.notifications.requests.get") as get:
+        response = get.return_value
+        response.status_code = 200
+        response.text = '{"state": "not_open"}'
+        assert read_kv_json(
+            config=CloudflareKVConfig(
+                account_id="account",
+                namespace_id="namespace",
+                api_token=FAKE_CREDENTIAL,
+            ),
+            cache_key="regybox:v1:key",
+        ) == {"state": "not_open"}
+        response.raise_for_status.assert_called_once_with()
+
+
+def test_write_kv_json_sends_payload() -> None:
+    with patch("regybox.notifications.requests.put") as put:
+        response = put.return_value
+        write_kv_json(
+            config=CloudflareKVConfig(
+                account_id="account",
+                namespace_id="namespace",
+                api_token=FAKE_CREDENTIAL,
+            ),
+            cache_key="regybox:v1:key",
+            payload={"failureNotificationFingerprint": "failure:enroll:x:y"},
+        )
+        assert put.call_args.kwargs["params"] == {"expiration_ttl": str(KV_TTL_SECONDS)}
+        assert (
+            json.loads(put.call_args.kwargs["data"])["failureNotificationFingerprint"]
+            == "failure:enroll:x:y"
+        )
+        response.raise_for_status.assert_called_once_with()
+
+
+def test_notifications_main_suppresses_repeated_cached_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_file = tmp_path / "env_failure"
+    log_path = tmp_path / "enroll.log"
+    payload = {
+        "error_code": "class_overbooked",
+        "user_title": "Class and waitlist are full",
+        "user_message": "No spots are available.",
+        "technical_message": "Class is overbooked",
+    }
+    log_path.write_text(
+        f"ERROR {REGYBOX_USER_ERROR_PREFIX}{json.dumps(payload)}",
+        encoding="utf-8",
+    )
+    fingerprint = "failure:enroll:class_overbooked:Class and waitlist are full"
+
+    monkeypatch.setenv("GITHUB_ENV", str(env_file))
+    monkeypatch.setenv("ENROLL_RESULT", "failure")
+    monkeypatch.setenv("CLASS_TYPE", "WOD")
+    monkeypatch.setenv("CLASS_DATE", "2026-03-04")
+    monkeypatch.setenv("CLASS_TIME", "06:30")
+    monkeypatch.setenv("ENROLL_LOG_PATH", str(log_path))
+    monkeypatch.setenv("CACHE_KEY", "regybox:v1:key")
+    with (
+        patch("regybox.notifications.CloudflareKVConfig.from_env"),
+        patch(
+            "regybox.notifications.read_kv_json",
+            return_value={"failureNotificationFingerprint": fingerprint},
+        ),
+        patch("regybox.notifications.write_kv_json") as write_kv_json,
+    ):
+        notifications_module.main()
+
+    assert "SHOULD_SEND_EMAIL<<REGYBOX_SHOULD_SEND_EMAIL_EOF\nfalse" in env_file.read_text(
+        encoding="utf-8"
+    )
+    write_kv_json.assert_not_called()
+
+
+def test_notifications_main_sends_and_caches_changed_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_file = tmp_path / "env_failure"
+    log_path = tmp_path / "enroll.log"
+    payload = {
+        "error_code": "class_overbooked",
+        "user_title": "Class and waitlist are full",
+        "user_message": "No spots are available.",
+        "technical_message": "Class is overbooked",
+    }
+    log_path.write_text(
+        f"ERROR {REGYBOX_USER_ERROR_PREFIX}{json.dumps(payload)}",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("GITHUB_ENV", str(env_file))
+    monkeypatch.setenv("ENROLL_RESULT", "failure")
+    monkeypatch.setenv("CLASS_TYPE", "WOD")
+    monkeypatch.setenv("CLASS_DATE", "2026-03-04")
+    monkeypatch.setenv("CLASS_TIME", "06:30")
+    monkeypatch.setenv("ENROLL_LOG_PATH", str(log_path))
+    monkeypatch.setenv("CACHE_KEY", "regybox:v1:key")
+    with (
+        patch("regybox.notifications.CloudflareKVConfig.from_env") as from_env,
+        patch(
+            "regybox.notifications.read_kv_json",
+            return_value={"failureNotificationFingerprint": "failure:enroll:login_error:old"},
+        ),
+        patch("regybox.notifications.write_kv_json") as write_kv_json,
+    ):
+        notifications_module.main()
+
+    assert "SHOULD_SEND_EMAIL<<REGYBOX_SHOULD_SEND_EMAIL_EOF\ntrue" in env_file.read_text(
+        encoding="utf-8"
+    )
+    write_kv_json.assert_called_once()
+    assert write_kv_json.call_args.kwargs["config"] == from_env.return_value
+    assert write_kv_json.call_args.kwargs["cache_key"] == "regybox:v1:key"
+    assert (
+        write_kv_json.call_args.kwargs["payload"]["failureNotificationFingerprint"]
+        == "failure:enroll:class_overbooked:Class and waitlist are full"
+    )
+
+
+def test_notifications_main_sends_when_kv_check_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_file = tmp_path / "env_failure"
+    log_path = tmp_path / "enroll.log"
+    log_path.write_text("ERROR requests.exceptions.Timeout: timed out", encoding="utf-8")
+
+    monkeypatch.setenv("GITHUB_ENV", str(env_file))
+    monkeypatch.setenv("ENROLL_RESULT", "failure")
+    monkeypatch.setenv("CLASS_TYPE", "WOD")
+    monkeypatch.setenv("CLASS_DATE", "2026-03-04")
+    monkeypatch.setenv("CLASS_TIME", "06:30")
+    monkeypatch.setenv("ENROLL_LOG_PATH", str(log_path))
+    monkeypatch.setenv("CACHE_KEY", "regybox:v1:key")
+    with patch("regybox.notifications.CloudflareKVConfig.from_env", side_effect=ValueError):
+        notifications_module.main()
+
+    assert "SHOULD_SEND_EMAIL<<REGYBOX_SHOULD_SEND_EMAIL_EOF\ntrue" in env_file.read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_regybox.py
+++ b/tests/test_regybox.py
@@ -12,6 +12,7 @@ from hypothesis.strategies import integers
 
 from regybox import __version__
 from regybox.exceptions import (
+    ClassIsOverbookedError,
     ClassNotFoundError,
     ClassNotOpenError,
     NoClassesFoundError,
@@ -142,6 +143,58 @@ def test_main_enrolls_when_class_open(
     mock_class.enroll.assert_called_once()
     assert result == OperationResult(operation="enroll", status="success", class_type="WOD Rato")
     assert "Inscrito" in caplog.text or "Runtime:" in caplog.text
+    assert "Attempting to enroll in WOD Rato on 2026-03-10 at 06:30" in caplog.text
+
+
+def test_main_attempts_to_enroll_when_class_full_with_waitlist(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_class: MagicMock = MagicMock()
+    mock_class.name = "WOD Rato"
+    mock_class.is_open = True
+    mock_class.is_full = True
+    mock_class.is_overbooked = False
+    mock_class.enroll.return_value = "Lista de espera"
+    with (
+        caplog.at_level(logging.INFO),
+        patch("regybox.regybox.check_cal"),
+        patch("regybox.regybox.get_classes", return_value=[mock_class]),
+        patch("regybox.regybox.pick_class", return_value=mock_class),
+    ):
+        result = main(
+            class_date="2026-03-10",
+            class_time="06:30",
+            class_type="WOD Rato",
+            check_calendar=False,
+            timeout=60,
+        )
+
+    mock_class.enroll.assert_called_once()
+    assert result == OperationResult(operation="enroll", status="success", class_type="WOD Rato")
+    assert "WOD Rato on 2026-03-10 at 06:30 is full; attempting waitlist enrollment" in caplog.text
+
+
+def test_main_raises_overbooked_when_class_and_waitlist_full() -> None:
+    mock_class: MagicMock = MagicMock()
+    mock_class.name = "WOD Rato"
+    mock_class.is_open = True
+    mock_class.is_full = True
+    mock_class.is_overbooked = True
+    with (
+        patch("regybox.regybox.check_cal"),
+        patch("regybox.regybox.get_classes", return_value=[mock_class]),
+        patch("regybox.regybox.pick_class", return_value=mock_class),
+        pytest.raises(ClassIsOverbookedError),
+    ):
+        main(
+            class_date="2026-03-10",
+            class_time="06:30",
+            class_type="WOD Rato",
+            check_calendar=False,
+            timeout=60,
+        )
+
+    mock_class.enroll.assert_not_called()
 
 
 def test_parse_class_types_supports_comma_separated_candidates() -> None:
@@ -297,6 +350,34 @@ def test_main_treats_not_open_as_noop_when_requested() -> None:
     assert result == OperationResult(operation="enroll", status="noop", class_type="WOD Rato")
 
 
+def test_main_logs_not_open_cache_metadata_when_time_to_enroll_known(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_class: MagicMock = MagicMock()
+    mock_class.name = "WOD Rato"
+    mock_class.is_open = False
+    mock_class.time_to_enroll = 3600
+    with (
+        caplog.at_level(logging.INFO),
+        patch("regybox.regybox.check_cal"),
+        patch("regybox.regybox.get_classes", return_value=[mock_class]),
+        patch("regybox.regybox.pick_class", return_value=mock_class),
+    ):
+        result = main(
+            class_date="2026-03-10",
+            class_time="06:30",
+            class_type="WOD Rato",
+            check_calendar=False,
+            timeout=60,
+            operation_options=OperationOptions(not_open_is_noop=True),
+        )
+
+    assert result == OperationResult(operation="enroll", status="noop", class_type="WOD Rato")
+    assert "REGYBOX_CACHE_STATE=not_open" in caplog.text
+    assert "enrollment_opens_at=" in caplog.text
+    assert "last_checked_at=" in caplog.text
+
+
 def test_main_treats_not_open_without_timer_as_noop_when_requested() -> None:
     mock_class: MagicMock = MagicMock()
     mock_class.name = "WOD Rato"
@@ -333,12 +414,13 @@ def test_main_timeout_is_noop_when_requested() -> None:
     assert result == OperationResult(operation="enroll", status="noop", class_type="WOD Rato")
 
 
-def test_main_unenrolls_when_enrolled() -> None:
+def test_main_unenrolls_when_enrolled(caplog: pytest.LogCaptureFixture) -> None:
     mock_class: MagicMock = MagicMock()
     mock_class.name = "WOD Rato"
     mock_class.user_is_enrolled = True
     mock_class.unenroll.return_value = "Desmarcado"
     with (
+        caplog.at_level(logging.INFO),
         patch("regybox.regybox.check_cal"),
         patch("regybox.regybox.get_classes", return_value=[mock_class]),
         patch("regybox.regybox.pick_class", return_value=mock_class),
@@ -353,6 +435,7 @@ def test_main_unenrolls_when_enrolled() -> None:
 
     mock_class.unenroll.assert_called_once()
     assert result == OperationResult(operation="unenroll", status="success", class_type="WOD Rato")
+    assert "Attempting to unenroll from WOD Rato on 2026-03-10 at 06:30" in caplog.text
 
 
 def test_main_unenroll_noops_when_not_enrolled() -> None:

--- a/tests/test_regybox.py
+++ b/tests/test_regybox.py
@@ -197,6 +197,34 @@ def test_main_raises_overbooked_when_class_and_waitlist_full() -> None:
     mock_class.enroll.assert_not_called()
 
 
+def test_main_noops_when_already_enrolled_even_if_overbooked(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_class: MagicMock = MagicMock()
+    mock_class.name = "WOD Rato"
+    mock_class.is_open = True
+    mock_class.is_full = True
+    mock_class.is_overbooked = True
+    mock_class.user_is_enrolled = True
+    with (
+        caplog.at_level(logging.INFO),
+        patch("regybox.regybox.check_cal"),
+        patch("regybox.regybox.get_classes", return_value=[mock_class]),
+        patch("regybox.regybox.pick_class", return_value=mock_class),
+    ):
+        result = main(
+            class_date="2026-03-10",
+            class_time="06:30",
+            class_type="WOD Rato",
+            check_calendar=False,
+            timeout=60,
+        )
+
+    mock_class.enroll.assert_not_called()
+    assert result == OperationResult(operation="enroll", status="noop", class_type="WOD Rato")
+    assert "Already enrolled in class" in caplog.text
+
+
 def test_parse_class_types_supports_comma_separated_candidates() -> None:
     assert parse_class_types(" WOD, Weekend WOD ,, Open Gym ") == [
         "WOD",


### PR DESCRIPTION
- retry transient Regybox request failures with shared timeouts
- cache not-open enrollment windows and throttle scheduler dispatches
- suppress repeated unchanged failure emails with KV fingerprints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Enhanced enrollment scheduling that intelligently reschedules when previously unavailable classes become open
  * Smart failure notification system that suppresses repeated duplicate failure messages for the same issue

* **Improvements**
  * More reliable HTTP connections with improved timeout and retry handling
  * Better logging and diagnostics for enrollment attempts and class availability tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->