### PR TITLE
fix: make class operation cache key optional

### DIFF
--- a/.github/workflows/class_operation.yml
+++ b/.github/workflows/class_operation.yml
@@ -25,8 +25,9 @@ on: # yamllint disable-line rule:truthy
         required: false
         default: ""
       cache-key:
-        description: Cloudflare KV cache key to update after a successful state change.
-        required: true
+        description: Optional Cloudflare KV cache key to update after a successful state change.
+        required: false
+        default: ""
       calendar-fingerprint:
         description: Stable calendar event identity used for debugging/cache value payloads.
         required: false

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -39,6 +39,10 @@ def test_class_operation_workflow_exposes_dispatch_and_kv_inputs() -> None:
     assert "calendar-event-name: ${{ inputs.calendar-event-name }}" in workflow_text
     assert "timeout-seconds: 900" in workflow_text
     assert "not-open-is-noop: true" in workflow_text
+    cache_key_start = workflow_text.index("      cache-key:")
+    calendar_fingerprint_start = workflow_text.index("      calendar-fingerprint:")
+    cache_key_block = workflow_text[cache_key_start:calendar_fingerprint_start]
+    assert "required: false" in cache_key_block
     assert "cf-account-id: ${{ secrets.CF_ACCOUNT_ID }}" in workflow_text
     assert "cf-kv-namespace-id: ${{ secrets.CF_KV_NAMESPACE_ID }}" in workflow_text
     assert "cf-kv-api-token: ${{ secrets.CF_KV_API_TOKEN }}" in workflow_text


### PR DESCRIPTION
- make the manual class operation cache key dispatch input optional
- cover optional cache key metadata in workflow tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Workflow dispatch now accepts cache-key as an optional parameter with an empty string default value, eliminating the requirement to specify it for every workflow run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->