### PR TITLE
fix: log enrollment open countdown

### DIFF
--- a/src/regybox/regybox.py
+++ b/src/regybox/regybox.py
@@ -116,8 +116,11 @@ def _closed_enrollment_result(
 ) -> OperationResult | None:
     if not options.not_open_is_noop:
         return None
-    LOGGER.info("Enrollment is not open; returning no-op result")
     if time_to_enroll is not None:
+        LOGGER.info(
+            f"Enrollment is not open; opens in {secs_to_str(time_to_enroll)}; "
+            "returning no-op result"
+        )
         last_checked_at = datetime.datetime.now(TIMEZONE)
         enrollment_opens_at = last_checked_at + datetime.timedelta(seconds=time_to_enroll)
         LOGGER.info(
@@ -125,6 +128,8 @@ def _closed_enrollment_result(
             f"enrollment_opens_at={enrollment_opens_at.isoformat()} "
             f"last_checked_at={last_checked_at.isoformat()}"
         )
+    else:
+        LOGGER.info("Enrollment is not open; returning no-op result")
     return _operation_result(
         operation="enroll",
         status="noop",

--- a/tests/test_regybox.py
+++ b/tests/test_regybox.py
@@ -480,6 +480,7 @@ def test_main_logs_not_open_cache_metadata_when_time_to_enroll_known(
         )
 
     assert result == OperationResult(operation="enroll", status="noop", class_type="WOD Rato")
+    assert "Enrollment is not open; opens in 1:00:00; returning no-op result" in caplog.text
     assert "REGYBOX_CACHE_STATE=not_open" in caplog.text
     assert "enrollment_opens_at=" in caplog.text
     assert "last_checked_at=" in caplog.text


### PR DESCRIPTION
- include remaining time when closed enrollment has a timer
- cover the countdown message in regybox tests