### PR TITLE
fix: retry empty class list responses

### DIFF
--- a/src/regybox/classes.py
+++ b/src/regybox/classes.py
@@ -2,6 +2,7 @@
 
 import datetime
 import re
+import time
 from dataclasses import dataclass, field
 from urllib.parse import urljoin
 
@@ -10,7 +11,13 @@ from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
 from regybox.common import LOGGER, TIMEZONE
-from regybox.connection import DOMAIN, get_classes_html, get_url_html
+from regybox.connection import (
+    DOMAIN,
+    RETRY_BACKOFF_FACTOR,
+    RETRY_TOTAL,
+    get_classes_html,
+    get_url_html,
+)
 from regybox.exceptions import (
     ClassIsOverbookedError,
     ClassNotFoundError,
@@ -358,6 +365,30 @@ def _find_script_containing(scripts: list[Tag], needle: str) -> str | None:
     return None
 
 
+def _get_classes_tags_with_retry(timestamp: int) -> list[Tag]:
+    """Fetch class tags, retrying when no classes are found.
+
+    Args:
+        timestamp: The class date timestamp in milliseconds.
+
+    Returns:
+        The parsed class tags, or an empty list for a valid response with no
+        classes.
+    """
+    for attempt in range(RETRY_TOTAL + 1):
+        res_html = get_classes_html(timestamp)
+        soup: BeautifulSoup = BeautifulSoup(res_html, "html.parser")
+        classes: list[Tag] = soup.find_all("div", attrs={"class": "filtro0"})
+        if classes:
+            return classes
+        if attempt == RETRY_TOTAL:
+            break
+        wait = RETRY_BACKOFF_FACTOR * (2**attempt)
+        LOGGER.warning(f"No classes found in response; retrying in {wait:.2f} seconds.")
+        time.sleep(wait)
+    return []
+
+
 def get_classes_tags(year: int, month: int, day: int) -> list[Tag]:
     """Fetch all class tags for a specific date.
 
@@ -374,9 +405,7 @@ def get_classes_tags(year: int, month: int, day: int) -> list[Tag]:
         NoClassesFoundError: If no classes are found for the specified date.
     """
     timestamp: int = int(datetime.datetime(year, month, day, tzinfo=TIMEZONE).timestamp() * 1000)
-    res_html = get_classes_html(timestamp)
-    soup: BeautifulSoup = BeautifulSoup(res_html, "html.parser")
-    classes: list[Tag] = soup.find_all("div", attrs={"class": "filtro0"})
+    classes = _get_classes_tags_with_retry(timestamp)
     if not classes:
         raise NoClassesFoundError(class_date=f"{year}-{month}-{day}")
     return classes

--- a/src/regybox/regybox.py
+++ b/src/regybox/regybox.py
@@ -116,8 +116,11 @@ def _closed_enrollment_result(
 ) -> OperationResult | None:
     if not options.not_open_is_noop:
         return None
-    LOGGER.info("Enrollment is not open; returning no-op result")
     if time_to_enroll is not None:
+        LOGGER.info(
+            f"Enrollment is not open; opens in {secs_to_str(time_to_enroll)}; "
+            "returning no-op result"
+        )
         last_checked_at = datetime.datetime.now(TIMEZONE)
         enrollment_opens_at = last_checked_at + datetime.timedelta(seconds=time_to_enroll)
         LOGGER.info(
@@ -125,6 +128,8 @@ def _closed_enrollment_result(
             f"enrollment_opens_at={enrollment_opens_at.isoformat()} "
             f"last_checked_at={last_checked_at.isoformat()}"
         )
+    else:
+        LOGGER.info("Enrollment is not open; returning no-op result")
     return _operation_result(
         operation="enroll",
         status="noop",

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -377,13 +377,36 @@ def test_pick_class_raises_when_not_found() -> None:
         )
 
 
-def test_get_classes_tags_raises_when_no_classes() -> None:
-    """get_classes_tags raises NoClassesFoundError when HTML has no filtro0."""
+def test_get_classes_tags_raises_when_no_classes_after_retries() -> None:
+    """get_classes_tags raises NoClassesFoundError after empty retries."""
     with (
-        patch("regybox.classes.get_classes_html", return_value="<html><body></body></html>"),
+        patch(
+            "regybox.classes.get_classes_html", return_value="<html><body></body></html>"
+        ) as mock_get,
+        patch("regybox.classes.time.sleep") as mock_sleep,
         pytest.raises(NoClassesFoundError),
     ):
         get_classes_tags(2024, 7, 1)
+
+    assert mock_get.call_count == 5
+    assert mock_sleep.call_count == 4
+
+
+def test_get_classes_tags_retries_empty_class_response() -> None:
+    """get_classes_tags retries an empty class response before returning."""
+    open_html = resources.files(html_examples).joinpath("open.html").read_text()
+    with (
+        patch(
+            "regybox.classes.get_classes_html",
+            side_effect=["<html><body></body></html>", open_html],
+        ) as mock_get,
+        patch("regybox.classes.time.sleep") as mock_sleep,
+    ):
+        classes = get_classes_tags(2024, 7, 1)
+
+    assert len(classes) == 1
+    assert mock_get.call_count == 2
+    mock_sleep.assert_called_once_with(0.75)
 
 
 def test_get_classes_returns_list_of_classes() -> None:

--- a/tests/test_regybox.py
+++ b/tests/test_regybox.py
@@ -480,6 +480,7 @@ def test_main_logs_not_open_cache_metadata_when_time_to_enroll_known(
         )
 
     assert result == OperationResult(operation="enroll", status="noop", class_type="WOD Rato")
+    assert "Enrollment is not open; opens in 1:00:00; returning no-op result" in caplog.text
     assert "REGYBOX_CACHE_STATE=not_open" in caplog.text
     assert "enrollment_opens_at=" in caplog.text
     assert "last_checked_at=" in caplog.text


### PR DESCRIPTION
- retry class listing when parsing returns no classes
- keep no-classes failures after retries are exhausted
- cover retry success and exhausted retry cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when fetching available classes with automatic retry mechanism.

* **Refactor**
  * Enhanced logging to provide clearer feedback when enrollment is not yet open, including time until opening.

* **Tests**
  * Updated test coverage for class retrieval retry behavior and enrollment status messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->