### PR TITLE
fix: retry unopened enrollments within timeout

### DIFF
--- a/src/regybox/regybox.py
+++ b/src/regybox/regybox.py
@@ -290,12 +290,14 @@ def _wait_for_enrollable_class(
                 date=date,
                 class_time=class_time,
             )
-        if closed_result is not None:
-            return closed_result
         if picked.time_to_enroll is None:
+            if closed_result is not None:
+                return closed_result
             raise ClassNotOpenError
         remaining_timeout = max(0, math.ceil(timeout - elapsed))
         if picked.time_to_enroll > remaining_timeout:
+            if closed_result is not None:
+                return closed_result
             raise RegyboxTimeoutError(
                 remaining_timeout,
                 time_to_enroll=secs_to_str(picked.time_to_enroll),

--- a/tests/test_regybox.py
+++ b/tests/test_regybox.py
@@ -457,6 +457,38 @@ def test_main_treats_not_open_as_noop_when_requested() -> None:
     assert result == OperationResult(operation="enroll", status="noop", class_type="WOD Rato")
 
 
+def test_main_retries_not_open_noop_when_enrollment_opens_within_timeout() -> None:
+    closed_class: MagicMock = MagicMock()
+    closed_class.name = "WOD Rato"
+    closed_class.is_open = False
+    closed_class.time_to_enroll = 90
+
+    open_class: MagicMock = MagicMock()
+    open_class.name = "WOD Rato"
+    open_class.is_open = True
+    open_class.user_is_enrolled = False
+
+    with (
+        patch("regybox.regybox.check_cal"),
+        patch("regybox.regybox.get_classes", return_value=[closed_class]),
+        patch("regybox.regybox.pick_class", side_effect=[closed_class, open_class]),
+        patch("regybox.regybox.time.monotonic", side_effect=[0, 0, 60]),
+        patch("regybox.regybox.time.sleep") as sleep_mock,
+    ):
+        result = main(
+            class_date="2026-03-10",
+            class_time="06:30",
+            class_type="WOD Rato",
+            check_calendar=False,
+            timeout=900,
+            operation_options=OperationOptions(not_open_is_noop=True),
+        )
+
+    assert result == OperationResult(operation="enroll", status="success", class_type="WOD Rato")
+    sleep_mock.assert_called_once_with(60)
+    open_class.enroll.assert_called_once_with()
+
+
 def test_main_logs_not_open_cache_metadata_when_time_to_enroll_known(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
- keep polling unopened enrollments when they open before the timeout
- return no-op only when enrollment cannot open within the remaining wait
- add regression coverage for not-open retry behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the enrollment wait mechanism to intelligently continue retrying when enrollment is temporarily closed but expected to open soon, instead of prematurely ending the operation.

* **Tests**
  * Added comprehensive test coverage for scenarios where initially closed class enrollment becomes available before the operation timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->