### PR TITLE
feat: increase login retry attempts to 10

### DIFF
--- a/src/regybox/classes.py
+++ b/src/regybox/classes.py
@@ -13,8 +13,6 @@ from bs4.element import NavigableString, Tag
 from regybox.common import LOGGER, TIMEZONE
 from regybox.connection import (
     DOMAIN,
-    RETRY_BACKOFF_FACTOR,
-    RETRY_TOTAL,
     get_classes_html,
     get_url_html,
 )
@@ -26,6 +24,9 @@ from regybox.exceptions import (
     UnparseableError,
     UserAlreadyEnrolledError,
 )
+
+CLASS_RETRY_TOTAL: int = 4
+CLASS_RETRY_BACKOFF_FACTOR: float = 0.75
 
 
 def parse_capacity_value(value: str) -> int | None:
@@ -375,15 +376,15 @@ def _get_classes_tags_with_retry(timestamp: int) -> list[Tag]:
         The parsed class tags, or an empty list for a valid response with no
         classes.
     """
-    for attempt in range(RETRY_TOTAL + 1):
+    for attempt in range(CLASS_RETRY_TOTAL + 1):
         res_html = get_classes_html(timestamp)
         soup: BeautifulSoup = BeautifulSoup(res_html, "html.parser")
         classes: list[Tag] = soup.find_all("div", attrs={"class": "filtro0"})
         if classes:
             return classes
-        if attempt == RETRY_TOTAL:
+        if attempt == CLASS_RETRY_TOTAL:
             break
-        wait = RETRY_BACKOFF_FACTOR * (2**attempt)
+        wait = CLASS_RETRY_BACKOFF_FACTOR * (2**attempt)
         LOGGER.warning(f"No classes found in response; retrying in {wait:.2f} seconds.")
         time.sleep(wait)
     return []

--- a/src/regybox/connection.py
+++ b/src/regybox/connection.py
@@ -18,7 +18,7 @@ from regybox.utils.singleton import Singleton
 
 DOMAIN: str = "https://www.regybox.pt/app/app_nova/"
 DEFAULT_TIMEOUT_SECONDS: int = 15
-RETRY_TOTAL: int = 4
+RETRY_TOTAL: int = 10
 RETRY_BACKOFF_FACTOR: float = 0.75
 RETRY_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
 HEADERS: dict[str, str] = {

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -133,9 +133,11 @@ def test_regybox_session_retry_adapter_retries_transient_statuses(
 
     adapter = mount.call_args_list[1].args[1]
     retries = adapter.max_retries
-    assert retries.total >= 3
-    assert retries.connect >= 3
-    assert retries.read >= 3
+    assert retries.total == 10
+    assert retries.connect == 10
+    assert retries.read == 10
+    assert retries.status == 10
+    assert retries.backoff_factor == pytest.approx(0.75)
     assert {429, 500, 502, 503, 504}.issubset(retries.status_forcelist)
 
 


### PR DESCRIPTION
## Summary
- Raise the shared connection retry budget from 4 to 10 to better tolerate transient login and session failures.
- Keep class-fetch retries separate with their own local retry settings so class lookups preserve existing behavior.
- Update the retry adapter test to assert the new retry configuration explicitly.

## Testing
- Updated unit coverage for the retry adapter configuration.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience and retry behavior for class data fetching and connection handling with optimized backoff strategies.

* **Tests**
  * Enhanced test assertions for retry configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->