### PR TITLE
fix: keep retry backoff under one minute

### DIFF
--- a/src/regybox/connection.py
+++ b/src/regybox/connection.py
@@ -19,7 +19,7 @@ from regybox.utils.singleton import Singleton
 DOMAIN: str = "https://www.regybox.pt/app/app_nova/"
 DEFAULT_TIMEOUT_SECONDS: int = 15
 RETRY_TOTAL: int = 10
-RETRY_BACKOFF_FACTOR: float = 0.75
+RETRY_BACKOFF_FACTOR: float = 0.05
 RETRY_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
 HEADERS: dict[str, str] = {
     "Accept": "text/html, */*; q=0.01",
@@ -65,6 +65,7 @@ class RegyboxSession(requests.Session, metaclass=Singleton):
             backoff_factor=RETRY_BACKOFF_FACTOR,
             status_forcelist=RETRY_STATUS_CODES,
             allowed_methods=frozenset({"HEAD", "GET", "POST", "PUT", "DELETE", "OPTIONS"}),
+            respect_retry_after_header=False,
         )
         adapter: HTTPAdapter = HTTPAdapter(max_retries=retry_policy)
         self.mount("http://", adapter)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,10 +4,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+from urllib3.util.retry import Retry
 
 from regybox.connection import (
     DEFAULT_TIMEOUT_SECONDS,
     HEADERS,
+    RETRY_BACKOFF_FACTOR,
+    RETRY_TOTAL,
     RegyboxSession,
     get_classes_html,
     get_classes_params,
@@ -133,11 +136,12 @@ def test_regybox_session_retry_adapter_retries_transient_statuses(
 
     adapter = mount.call_args_list[1].args[1]
     retries = adapter.max_retries
-    assert retries.total == 10
-    assert retries.connect == 10
-    assert retries.read == 10
-    assert retries.status == 10
-    assert retries.backoff_factor == pytest.approx(0.75)
+    assert retries.total == RETRY_TOTAL
+    assert retries.connect == RETRY_TOTAL
+    assert retries.read == RETRY_TOTAL
+    assert retries.status == RETRY_TOTAL
+    assert retries.backoff_factor == pytest.approx(RETRY_BACKOFF_FACTOR)
+    assert not retries.respect_retry_after_header
     assert {429, 500, 502, 503, 504}.issubset(retries.status_forcelist)
 
 
@@ -147,3 +151,14 @@ def test_regybox_session_get_session_params() -> None:
         "y": "*testuser",
         "ignore": "regybox.pt/app/app",
     }
+
+
+def test_retry_backoff_budget_stays_under_one_minute() -> None:
+    retry = Retry(total=RETRY_TOTAL, backoff_factor=RETRY_BACKOFF_FACTOR)
+
+    backoff_times: list[float] = []
+    for _ in range(RETRY_TOTAL):
+        retry = retry.increment(method="GET", url="https://example.com")
+        backoff_times.append(retry.get_backoff_time())
+
+    assert sum(backoff_times) < 60


### PR DESCRIPTION
- lower retry backoff factor for faster retry exhaustion
- ignore retry-after headers during login retries
- cover retry timing budget in connection tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced retry wait times for HTTP requests, improving responsiveness after transient failures.
  * Disabled automatic use of server-provided retry delays, making retry behavior more consistent.
* **Tests**
  * Updated retry checks to use shared configuration values.
  * Added coverage to ensure retry backoff stays within a reasonable time budget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->