### PR TITLE
fix: reduce retry backoff factor

### DIFF
--- a/src/regybox/connection.py
+++ b/src/regybox/connection.py
@@ -19,7 +19,7 @@ from regybox.utils.singleton import Singleton
 DOMAIN: str = "https://www.regybox.pt/app/app_nova/"
 DEFAULT_TIMEOUT_SECONDS: int = 15
 RETRY_TOTAL: int = 10
-RETRY_BACKOFF_FACTOR: float = 0.75
+RETRY_BACKOFF_FACTOR: float = 0.05
 RETRY_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
 HEADERS: dict[str, str] = {
     "Accept": "text/html, */*; q=0.01",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,10 +4,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+from urllib3.util.retry import Retry
 
 from regybox.connection import (
     DEFAULT_TIMEOUT_SECONDS,
     HEADERS,
+    RETRY_BACKOFF_FACTOR,
+    RETRY_TOTAL,
     RegyboxSession,
     get_classes_html,
     get_classes_params,
@@ -133,11 +136,12 @@ def test_regybox_session_retry_adapter_retries_transient_statuses(
 
     adapter = mount.call_args_list[1].args[1]
     retries = adapter.max_retries
-    assert retries.total == 10
-    assert retries.connect == 10
-    assert retries.read == 10
-    assert retries.status == 10
-    assert retries.backoff_factor == pytest.approx(0.75)
+    assert retries.total == RETRY_TOTAL
+    assert retries.connect == RETRY_TOTAL
+    assert retries.read == RETRY_TOTAL
+    assert retries.status == RETRY_TOTAL
+    assert retries.backoff_factor == pytest.approx(RETRY_BACKOFF_FACTOR)
+    assert retries.respect_retry_after_header
     assert {429, 500, 502, 503, 504}.issubset(retries.status_forcelist)
 
 
@@ -147,3 +151,14 @@ def test_regybox_session_get_session_params() -> None:
         "y": "*testuser",
         "ignore": "regybox.pt/app/app",
     }
+
+
+def test_retry_client_backoff_budget_stays_under_one_minute() -> None:
+    retry = Retry(total=RETRY_TOTAL, backoff_factor=RETRY_BACKOFF_FACTOR)
+
+    backoff_times: list[float] = []
+    for _ in range(RETRY_TOTAL):
+        retry = retry.increment(method="GET", url="https://example.com")
+        backoff_times.append(retry.get_backoff_time())
+
+    assert sum(backoff_times) < 60


### PR DESCRIPTION
### Motivation

- Reduce the HTTP retry backoff so the cumulative retry wait stays under a practical limit (under one minute) for transient errors. 
- Make tests reference retry configuration constants to avoid hard-coded values and to validate retry behavior explicitly.

### Description

- Change the retry backoff factor from `0.75` to `0.05` by updating `RETRY_BACKOFF_FACTOR` in `src/regybox/connection.py`.
- Update tests to consume `RETRY_BACKOFF_FACTOR` and `RETRY_TOTAL` from the module instead of hard-coded numbers in `tests/test_connection.py`.
- Add an assertion that the adapter's `respect_retry_after_header` flag is enabled in the session retry configuration.
- Add a new test `test_retry_client_backoff_budget_stays_under_one_minute` that computes cumulative backoff times and asserts the sum is below 60 seconds.

### Testing

- Ran the updated unit tests in `tests/test_connection.py`, which include the modified retry assertions and the new backoff budget test, and they passed.
- The session retry configuration assertions for `total`, `connect`, `read`, `status`, and `backoff_factor` were validated in the test suite and succeeded.
- The new cumulative backoff budget test executed and confirmed the backoff budget stays under one minute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b547ec2e0833189b3fb8f2e8915ed)