### PR TITLE
fix: classify retried enrollment by final result

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,7 +151,8 @@ runs:
         set -euo pipefail
         cache_should_update=false
         if [[ "${ENROLL_OUTCOME}" == "success" ]]; then
-          if grep -q "REGYBOX_RESULT=noop" "${ENROLL_LOG_PATH}"; then
+          final_result_line="$(grep "REGYBOX_RESULT=" "${ENROLL_LOG_PATH}" | tail -n 1 || true)"
+          if [[ "${final_result_line}" == *"REGYBOX_RESULT=noop"* ]]; then
             result=noop
             if grep -q "REGYBOX_CACHE_STATE=not_open" "${ENROLL_LOG_PATH}"; then
               cache_should_update=true

--- a/src/regybox/regybox.py
+++ b/src/regybox/regybox.py
@@ -277,15 +277,15 @@ def _wait_for_enrollable_class(
         resolved_class_type = _resolved_class_type(picked, class_types[0])
         if picked.is_open:
             return picked
-        closed_result = _closed_enrollment_result(
-            options=options,
-            resolved_class_type=resolved_class_type,
-            time_to_enroll=picked.time_to_enroll,
-        )
         # Non-full closed error cards are treated as deadline-expired/not-open.
         # Full closed error cards are intentionally classified as overbooked,
         # even though that can miss the rare "full and starting soon" case.
         if _class_bool(picked, "enrollment_deadline_expired"):
+            closed_result = _closed_enrollment_result(
+                options=options,
+                resolved_class_type=resolved_class_type,
+                time_to_enroll=picked.time_to_enroll,
+            )
             if closed_result is not None:
                 return closed_result
             raise ClassNotOpenError
@@ -296,11 +296,21 @@ def _wait_for_enrollable_class(
                 class_time=class_time,
             )
         if picked.time_to_enroll is None:
+            closed_result = _closed_enrollment_result(
+                options=options,
+                resolved_class_type=resolved_class_type,
+                time_to_enroll=picked.time_to_enroll,
+            )
             if closed_result is not None:
                 return closed_result
             raise ClassNotOpenError
         remaining_timeout = max(0, math.ceil(timeout - elapsed))
         if picked.time_to_enroll > remaining_timeout:
+            closed_result = _closed_enrollment_result(
+                options=options,
+                resolved_class_type=resolved_class_type,
+                time_to_enroll=picked.time_to_enroll,
+            )
             if closed_result is not None:
                 return closed_result
             raise RegyboxTimeoutError(

--- a/src/regybox/regybox.py
+++ b/src/regybox/regybox.py
@@ -280,48 +280,35 @@ def _wait_for_enrollable_class(
         # Non-full closed error cards are treated as deadline-expired/not-open.
         # Full closed error cards are intentionally classified as overbooked,
         # even though that can miss the rare "full and starting soon" case.
-        if _class_bool(picked, "enrollment_deadline_expired"):
-            closed_result = _closed_enrollment_result(
-                options=options,
-                resolved_class_type=resolved_class_type,
-                time_to_enroll=picked.time_to_enroll,
-            )
-            if closed_result is not None:
-                return closed_result
-            raise ClassNotOpenError
-        if _class_is_overbooked(picked):
+        deadline_expired = _class_bool(picked, "enrollment_deadline_expired")
+        if not deadline_expired and _class_is_overbooked(picked):
             _raise_overbooked(
                 resolved_class_type=resolved_class_type,
                 date=date,
                 class_time=class_time,
             )
-        if picked.time_to_enroll is None:
-            closed_result = _closed_enrollment_result(
-                options=options,
-                resolved_class_type=resolved_class_type,
-                time_to_enroll=picked.time_to_enroll,
-            )
-            if closed_result is not None:
-                return closed_result
-            raise ClassNotOpenError
+        time_to_enroll = picked.time_to_enroll
         remaining_timeout = max(0, math.ceil(timeout - elapsed))
-        if picked.time_to_enroll > remaining_timeout:
+        wait_exceeds_timeout = time_to_enroll is not None and time_to_enroll > remaining_timeout
+        if deadline_expired or time_to_enroll is None or wait_exceeds_timeout:
             closed_result = _closed_enrollment_result(
                 options=options,
                 resolved_class_type=resolved_class_type,
-                time_to_enroll=picked.time_to_enroll,
+                time_to_enroll=time_to_enroll,
             )
             if closed_result is not None:
                 return closed_result
+            if deadline_expired or time_to_enroll is None:
+                raise ClassNotOpenError
             raise RegyboxTimeoutError(
                 remaining_timeout,
-                time_to_enroll=secs_to_str(picked.time_to_enroll),
+                time_to_enroll=secs_to_str(time_to_enroll),
             )
 
-        wait: int = snooze(picked.time_to_enroll)
+        wait: int = snooze(time_to_enroll)
         LOGGER.info(
             f"Waiting for {resolved_class_type} on {date.isoformat()} at {class_time} to be"
-            f" available, ETA in {secs_to_str(picked.time_to_enroll)}. Retrying in {wait} seconds."
+            f" available, ETA in {secs_to_str(time_to_enroll)}. Retrying in {wait} seconds."
         )
         time.sleep(wait)
     if options.not_open_is_noop:

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -23,6 +23,14 @@ def test_action_defaults_not_open_enrollment_to_noop() -> None:
     assert '    default: "true"' in action_lines[input_start:next_input]
 
 
+def test_action_classifies_enrollment_from_final_result_marker() -> None:
+    action_text = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+
+    assert 'grep "REGYBOX_RESULT=" "${ENROLL_LOG_PATH}" | tail -n 1' in action_text
+    assert '[[ "${final_result_line}" == *"REGYBOX_RESULT=noop"* ]]' in action_text
+    assert 'grep -q "REGYBOX_RESULT=noop" "${ENROLL_LOG_PATH}"' not in action_text
+
+
 def test_class_operation_workflow_exposes_dispatch_and_kv_inputs() -> None:
     workflow_text = (REPO_ROOT / ".github/workflows/class_operation.yml").read_text(
         encoding="utf-8"

--- a/tests/test_regybox.py
+++ b/tests/test_regybox.py
@@ -11,6 +11,7 @@ from hypothesis import given
 from hypothesis.strategies import integers
 
 from regybox import __version__
+from regybox.common import LOGGER
 from regybox.exceptions import (
     ClassIsOverbookedError,
     ClassNotFoundError,
@@ -490,11 +491,12 @@ def test_main_retries_not_open_noop_when_enrollment_opens_within_timeout(
     assert result == OperationResult(operation="enroll", status="success", class_type="WOD Rato")
     sleep_mock.assert_called_once_with(60)
     open_class.enroll.assert_called_once_with()
-    assert "Waiting for WOD Rato" in caplog.text
-    assert "returning no-op result" not in caplog.text
-    assert "REGYBOX_RESULT=noop" not in caplog.text
-    assert "REGYBOX_CACHE_STATE=not_open" not in caplog.text
-    assert "REGYBOX_RESULT=success" in caplog.text
+    structured_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == LOGGER.name and record.getMessage().startswith("REGYBOX_")
+    ]
+    assert structured_messages == ["REGYBOX_RESULT=success operation=enroll class_type=WOD Rato"]
 
 
 def test_main_logs_not_open_cache_metadata_when_time_to_enroll_known(

--- a/tests/test_regybox.py
+++ b/tests/test_regybox.py
@@ -457,7 +457,9 @@ def test_main_treats_not_open_as_noop_when_requested() -> None:
     assert result == OperationResult(operation="enroll", status="noop", class_type="WOD Rato")
 
 
-def test_main_retries_not_open_noop_when_enrollment_opens_within_timeout() -> None:
+def test_main_retries_not_open_noop_when_enrollment_opens_within_timeout(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     closed_class: MagicMock = MagicMock()
     closed_class.name = "WOD Rato"
     closed_class.is_open = False
@@ -469,6 +471,7 @@ def test_main_retries_not_open_noop_when_enrollment_opens_within_timeout() -> No
     open_class.user_is_enrolled = False
 
     with (
+        caplog.at_level(logging.INFO),
         patch("regybox.regybox.check_cal"),
         patch("regybox.regybox.get_classes", return_value=[closed_class]),
         patch("regybox.regybox.pick_class", side_effect=[closed_class, open_class]),
@@ -487,6 +490,11 @@ def test_main_retries_not_open_noop_when_enrollment_opens_within_timeout() -> No
     assert result == OperationResult(operation="enroll", status="success", class_type="WOD Rato")
     sleep_mock.assert_called_once_with(60)
     open_class.enroll.assert_called_once_with()
+    assert "Waiting for WOD Rato" in caplog.text
+    assert "returning no-op result" not in caplog.text
+    assert "REGYBOX_RESULT=noop" not in caplog.text
+    assert "REGYBOX_CACHE_STATE=not_open" not in caplog.text
+    assert "REGYBOX_RESULT=success" in caplog.text
 
 
 def test_main_logs_not_open_cache_metadata_when_time_to_enroll_known(


### PR DESCRIPTION
- avoid emitting terminal no-op markers while enrollment retries remain
- use final structured result for cache and email handling
- cover retry-to-success logs and action classification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how enrollment outcomes are detected from logs, making “no-op” and success results more reliable.
  * Refined retry handling so closed-enrollment checks run only in the situations where they apply, reducing incorrect reuse of prior results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->