### PR TITLE
fix: Use centralized retry config for class fetching and update tests

### DIFF
--- a/src/regybox/classes.py
+++ b/src/regybox/classes.py
@@ -365,27 +365,35 @@ def _find_script_containing(scripts: list[Tag], needle: str) -> str | None:
     return None
 
 
-def _get_classes_tags_with_retry(timestamp: int) -> list[Tag]:
+def _get_classes_tags_with_retry(
+    timestamp: int,
+    *,
+    retry_total: int = RETRY_TOTAL,
+    retry_backoff_factor: float = RETRY_BACKOFF_FACTOR,
+) -> list[Tag]:
     """Fetch class tags, retrying when no classes are found.
 
     Args:
         timestamp: The class date timestamp in milliseconds.
+        retry_total: The number of empty responses to retry after the initial
+            request.
+        retry_backoff_factor: The base delay for exponential retry backoff.
 
     Returns:
         The parsed class tags, or an empty list for a valid response with no
         classes.
     """
-    for attempt in range(RETRY_TOTAL + 1):
+    max_fetch_attempts = retry_total + 1
+    for attempt in range(max_fetch_attempts):
         res_html = get_classes_html(timestamp)
         soup: BeautifulSoup = BeautifulSoup(res_html, "html.parser")
         classes: list[Tag] = soup.find_all("div", attrs={"class": "filtro0"})
         if classes:
             return classes
-        if attempt == RETRY_TOTAL:
-            break
-        wait = RETRY_BACKOFF_FACTOR * (2**attempt)
-        LOGGER.warning(f"No classes found in response; retrying in {wait:.2f} seconds.")
-        time.sleep(wait)
+        if attempt < retry_total:
+            wait = retry_backoff_factor * (2**attempt)
+            LOGGER.warning(f"No classes found in response; retrying in {wait:.2f} seconds.")
+            time.sleep(wait)
     return []
 
 

--- a/src/regybox/classes.py
+++ b/src/regybox/classes.py
@@ -13,8 +13,6 @@ from bs4.element import NavigableString, Tag
 from regybox.common import LOGGER, TIMEZONE
 from regybox.connection import (
     DOMAIN,
-    RETRY_BACKOFF_FACTOR,
-    RETRY_TOTAL,
     get_classes_html,
     get_url_html,
 )
@@ -26,6 +24,9 @@ from regybox.exceptions import (
     UnparseableError,
     UserAlreadyEnrolledError,
 )
+
+EMPTY_CLASS_RETRY_TOTAL: int = 10
+EMPTY_CLASS_RETRY_BACKOFF_FACTOR: float = 0.05
 
 
 def parse_capacity_value(value: str) -> int | None:
@@ -368,8 +369,8 @@ def _find_script_containing(scripts: list[Tag], needle: str) -> str | None:
 def _get_classes_tags_with_retry(
     timestamp: int,
     *,
-    retry_total: int = RETRY_TOTAL,
-    retry_backoff_factor: float = RETRY_BACKOFF_FACTOR,
+    retry_total: int = EMPTY_CLASS_RETRY_TOTAL,
+    retry_backoff_factor: float = EMPTY_CLASS_RETRY_BACKOFF_FACTOR,
 ) -> list[Tag]:
     """Fetch class tags, retrying when no classes are found.
 

--- a/src/regybox/classes.py
+++ b/src/regybox/classes.py
@@ -13,6 +13,8 @@ from bs4.element import NavigableString, Tag
 from regybox.common import LOGGER, TIMEZONE
 from regybox.connection import (
     DOMAIN,
+    RETRY_BACKOFF_FACTOR,
+    RETRY_TOTAL,
     get_classes_html,
     get_url_html,
 )
@@ -24,9 +26,6 @@ from regybox.exceptions import (
     UnparseableError,
     UserAlreadyEnrolledError,
 )
-
-CLASS_RETRY_TOTAL: int = 4
-CLASS_RETRY_BACKOFF_FACTOR: float = 0.75
 
 
 def parse_capacity_value(value: str) -> int | None:
@@ -376,15 +375,15 @@ def _get_classes_tags_with_retry(timestamp: int) -> list[Tag]:
         The parsed class tags, or an empty list for a valid response with no
         classes.
     """
-    for attempt in range(CLASS_RETRY_TOTAL + 1):
+    for attempt in range(RETRY_TOTAL + 1):
         res_html = get_classes_html(timestamp)
         soup: BeautifulSoup = BeautifulSoup(res_html, "html.parser")
         classes: list[Tag] = soup.find_all("div", attrs={"class": "filtro0"})
         if classes:
             return classes
-        if attempt == CLASS_RETRY_TOTAL:
+        if attempt == RETRY_TOTAL:
             break
-        wait = CLASS_RETRY_BACKOFF_FACTOR * (2**attempt)
+        wait = RETRY_BACKOFF_FACTOR * (2**attempt)
         LOGGER.warning(f"No classes found in response; retrying in {wait:.2f} seconds.")
         time.sleep(wait)
     return []

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -13,6 +13,7 @@ from regybox.classes import (
     parse_capacity_value,
     pick_class,
 )
+from regybox.connection import RETRY_BACKOFF_FACTOR, RETRY_TOTAL
 from regybox.exceptions import (
     ClassNotFoundError,
     NoClassesFoundError,
@@ -388,8 +389,8 @@ def test_get_classes_tags_raises_when_no_classes_after_retries() -> None:
     ):
         get_classes_tags(2024, 7, 1)
 
-    assert mock_get.call_count == 5
-    assert mock_sleep.call_count == 4
+    assert mock_get.call_count == RETRY_TOTAL + 1
+    assert mock_sleep.call_count == RETRY_TOTAL
 
 
 def test_get_classes_tags_retries_empty_class_response() -> None:
@@ -406,7 +407,18 @@ def test_get_classes_tags_retries_empty_class_response() -> None:
 
     assert len(classes) == 1
     assert mock_get.call_count == 2
-    mock_sleep.assert_called_once_with(0.75)
+    mock_sleep.assert_called_once_with(RETRY_BACKOFF_FACTOR)
+
+
+def test_get_classes_tags_empty_retry_budget_stays_under_one_minute() -> None:
+    """Empty class response retries have enough attempts.
+
+    They also avoid waiting too long.
+    """
+    waits = [RETRY_BACKOFF_FACTOR * (2**attempt) for attempt in range(RETRY_TOTAL)]
+
+    assert RETRY_TOTAL > 4
+    assert sum(waits) < 60
 
 
 def test_get_classes_returns_list_of_classes() -> None:

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -8,12 +8,12 @@ from bs4.element import PageElement, Tag
 
 from regybox.classes import (
     Class,
+    _get_classes_tags_with_retry,
     get_classes,
     get_classes_tags,
     parse_capacity_value,
     pick_class,
 )
-from regybox.connection import RETRY_BACKOFF_FACTOR, RETRY_TOTAL
 from regybox.exceptions import (
     ClassNotFoundError,
     NoClassesFoundError,
@@ -382,15 +382,13 @@ def test_get_classes_tags_raises_when_no_classes_after_retries() -> None:
     """get_classes_tags raises NoClassesFoundError after empty retries."""
     with (
         patch(
-            "regybox.classes.get_classes_html", return_value="<html><body></body></html>"
-        ) as mock_get,
-        patch("regybox.classes.time.sleep") as mock_sleep,
+            "regybox.classes._get_classes_tags_with_retry", return_value=[]
+        ) as mock_get_with_retry,
         pytest.raises(NoClassesFoundError),
     ):
         get_classes_tags(2024, 7, 1)
 
-    assert mock_get.call_count == RETRY_TOTAL + 1
-    assert mock_sleep.call_count == RETRY_TOTAL
+    mock_get_with_retry.assert_called_once()
 
 
 def test_get_classes_tags_retries_empty_class_response() -> None:
@@ -403,22 +401,31 @@ def test_get_classes_tags_retries_empty_class_response() -> None:
         ) as mock_get,
         patch("regybox.classes.time.sleep") as mock_sleep,
     ):
-        classes = get_classes_tags(2024, 7, 1)
+        classes = _get_classes_tags_with_retry(
+            1234567890000, retry_total=3, retry_backoff_factor=0.25
+        )
 
     assert len(classes) == 1
     assert mock_get.call_count == 2
-    mock_sleep.assert_called_once_with(RETRY_BACKOFF_FACTOR)
+    mock_sleep.assert_called_once_with(0.25)
 
 
-def test_get_classes_tags_empty_retry_budget_stays_under_one_minute() -> None:
-    """Empty class response retries have enough attempts.
+def test_get_classes_tags_empty_retry_budget_can_be_overridden() -> None:
+    """Empty class response retries can use an injected retry budget."""
+    with (
+        patch(
+            "regybox.classes.get_classes_html", return_value="<html><body></body></html>"
+        ) as mock_get,
+        patch("regybox.classes.time.sleep") as mock_sleep,
+    ):
+        classes = _get_classes_tags_with_retry(
+            1234567890000, retry_total=5, retry_backoff_factor=0.01
+        )
 
-    They also avoid waiting too long.
-    """
-    waits = [RETRY_BACKOFF_FACTOR * (2**attempt) for attempt in range(RETRY_TOTAL)]
-
-    assert RETRY_TOTAL > 4
-    assert sum(waits) < 60
+    assert classes == []
+    assert mock_get.call_count == 6
+    assert mock_sleep.call_count == 5
+    assert sum(call.args[0] for call in mock_sleep.call_args_list) < 1
 
 
 def test_get_classes_returns_list_of_classes() -> None:

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -7,6 +7,8 @@ from bs4 import BeautifulSoup
 from bs4.element import PageElement, Tag
 
 from regybox.classes import (
+    EMPTY_CLASS_RETRY_BACKOFF_FACTOR,
+    EMPTY_CLASS_RETRY_TOTAL,
     Class,
     _get_classes_tags_with_retry,
     get_classes,
@@ -376,6 +378,12 @@ def test_pick_class_raises_when_not_found() -> None:
             class_type="WOD Rato",
             class_date=class_.date,
         )
+
+
+def test_empty_class_retry_defaults_are_independent_from_connection_retries() -> None:
+    """Empty class retries use their own explicit retry budget."""
+    assert EMPTY_CLASS_RETRY_TOTAL == 10
+    assert pytest.approx(0.05) == EMPTY_CLASS_RETRY_BACKOFF_FACTOR
 
 
 def test_get_classes_tags_raises_when_no_classes_after_retries() -> None:


### PR DESCRIPTION
### Motivation

- Centralize retry configuration so class-fetching uses the shared retry budget and backoff defined in the connection layer instead of module-local constants.
- Ensure tests reference the same retry configuration and validate that the retry budget remains reasonable.

### Description

- Removed local `CLASS_RETRY_TOTAL` and `CLASS_RETRY_BACKOFF_FACTOR` and imported `RETRY_TOTAL` and `RETRY_BACKOFF_FACTOR` from `regybox.connection`.
- Updated `_get_classes_tags_with_retry` to iterate `range(RETRY_TOTAL + 1)` and compute backoff waits using `RETRY_BACKOFF_FACTOR * (2**attempt)`.
- Adjusted tests to import `RETRY_TOTAL` and `RETRY_BACKOFF_FACTOR`, to assert call counts using `RETRY_TOTAL`, and to assert sleep backoff uses `RETRY_BACKOFF_FACTOR`.
- Added `test_get_classes_tags_empty_retry_budget_stays_under_one_minute` to validate the total backoff wait stays under one minute and that `RETRY_TOTAL` is greater than 4.

### Testing

- Ran the class-related tests including `tests/test_classes.py` with `pytest`, specifically exercising `test_get_classes_tags_raises_when_no_classes_after_retries`, `test_get_classes_tags_retries_empty_class_response`, and the new `test_get_classes_tags_empty_retry_budget_stays_under_one_minute`.
- All modified and existing automated tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a437d790e188331a646c40685143672)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of class capacity values, including unlimited capacity, so class availability is displayed more reliably.
  * Made retry behavior for fetching class data more consistent, reducing the chance of temporary failures affecting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->