### PR TITLE
fix: honor moved recurring calendar instances in scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*
@@ -219,9 +219,6 @@ pyrightconfig.json
 # Built Visual Studio Code Extensions
 *.vsix
 
-# Local git worktrees used for isolated agent branches
-.worktrees/
-
 ### VisualStudioCode Patch ###
 # Ignore all local history of files
 .history
@@ -233,3 +230,4 @@ pyrightconfig.json
 tmp/
 temp/
 node_modules/
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*
@@ -232,3 +232,4 @@ pyrightconfig.json
 # local stuff
 tmp/
 temp/
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,4 @@ pyrightconfig.json
 # local stuff
 tmp/
 temp/
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -232,4 +232,3 @@ pyrightconfig.json
 # local stuff
 tmp/
 temp/
-node_modules/

--- a/cloudflare/regybox-scheduler/test/worker.test.js
+++ b/cloudflare/regybox-scheduler/test/worker.test.js
@@ -693,6 +693,145 @@ test("cancelled recurrence override removes instance without adding replacement"
   assert.deepEqual(events, []);
 });
 
+test("moved recurring override without summary inherits master summary", () => {
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260626T053000Z",
+    "RRULE:FREQ=WEEKLY;COUNT=2",
+    "END:VEVENT",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "RECURRENCE-ID:20260703T053000Z",
+    "DTSTART:20260703T073000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const events = expandCalendarEvents({
+    icsText: ics,
+    now: new Date("2026-06-29T00:00:00Z"),
+    lookaheadHours: 120,
+    calendarEventNames: ["Crossfit"],
+    timeZone: "Europe/Lisbon",
+  });
+
+  assert.deepEqual(
+    events.map((event) => [event.classDate, event.classTime, event.summary]),
+    [["2026-07-03", "08:30", "Crossfit"]],
+  );
+});
+
+test("cancelled recurrence override without summary still removes instance", () => {
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260626T053000Z",
+    "RRULE:FREQ=WEEKLY;COUNT=2",
+    "END:VEVENT",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "RECURRENCE-ID:20260703T053000Z",
+    "STATUS:CANCELLED",
+    "DTSTART:20260703T053000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const events = expandCalendarEvents({
+    icsText: ics,
+    now: new Date("2026-06-29T00:00:00Z"),
+    lookaheadHours: 120,
+    calendarEventNames: ["Crossfit"],
+    timeZone: "Europe/Lisbon",
+  });
+
+  assert.deepEqual(events, []);
+});
+
+test("cancelled recurrence override without dtstart still removes instance", () => {
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260626T053000Z",
+    "RRULE:FREQ=WEEKLY;COUNT=2",
+    "END:VEVENT",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "RECURRENCE-ID:20260703T053000Z",
+    "STATUS:CANCELLED",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const events = expandCalendarEvents({
+    icsText: ics,
+    now: new Date("2026-06-29T00:00:00Z"),
+    lookaheadHours: 120,
+    calendarEventNames: ["Crossfit"],
+    timeZone: "Europe/Lisbon",
+  });
+
+  assert.deepEqual(events, []);
+});
+
+test("buildPlan unenrolls cancelled recurring instance without new enroll", async () => {
+  const staleKey = "regybox:v1:calendar:weekly-class:2026-07-03T06:30:00.000Z";
+  const kv = makeKv(
+    new Map([
+      [
+        staleKey,
+        JSON.stringify({
+          state: "enrolled",
+          classDate: "2026-07-03",
+          classTime: "06:30",
+          classType: "WOD",
+          calendarEventName: "Crossfit",
+          calendarFingerprint: "weekly-class:2026-07-03T06:30:00.000Z",
+        }),
+      ],
+    ]),
+  );
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260626T053000Z",
+    "RRULE:FREQ=WEEKLY;COUNT=2",
+    "END:VEVENT",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "RECURRENCE-ID:20260703T053000Z",
+    "STATUS:CANCELLED",
+    "DTSTART:20260703T053000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const plan = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: ics,
+    now: new Date("2026-06-30T12:00:00Z"),
+  });
+
+  assert.deepEqual(
+    plan.dispatches.map((dispatch) => [
+      dispatch.operation,
+      dispatch.inputs["class-date"],
+      dispatch.inputs["class-time"],
+    ]),
+    [["unenroll", "2026-07-03", "06:30"]],
+  );
+});
+
 test("moved recurring instance dispatches enroll at new time and unenrolls stale slot", async () => {
   const staleKey = "regybox:v1:calendar:weekly-class:2026-07-03T06:30:00.000Z";
   const kv = makeKv(

--- a/cloudflare/regybox-scheduler/test/worker.test.js
+++ b/cloudflare/regybox-scheduler/test/worker.test.js
@@ -596,6 +596,158 @@ test("recurring calendar events respect EXDATE exclusions", () => {
   );
 });
 
+test("moved recurring instance uses override time instead of original slot", () => {
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260626T053000Z",
+    "RRULE:FREQ=WEEKLY;COUNT=2",
+    "EXDATE:20260703T053000Z",
+    "END:VEVENT",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "RECURRENCE-ID:20260703T053000Z",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260703T073000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const events = expandCalendarEvents({
+    icsText: ics,
+    now: new Date("2026-06-29T00:00:00Z"),
+    lookaheadHours: 120,
+    calendarEventNames: ["Crossfit"],
+    timeZone: "Europe/Lisbon",
+  });
+
+  assert.deepEqual(
+    events.map((event) => [event.classDate, event.classTime]),
+    [
+      ["2026-07-03", "08:30"],
+    ],
+  );
+});
+
+test("moved recurring instance uses override time without master EXDATE", () => {
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260626T053000Z",
+    "RRULE:FREQ=WEEKLY;COUNT=2",
+    "END:VEVENT",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "RECURRENCE-ID:20260703T053000Z",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260703T073000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const events = expandCalendarEvents({
+    icsText: ics,
+    now: new Date("2026-06-29T00:00:00Z"),
+    lookaheadHours: 120,
+    calendarEventNames: ["Crossfit"],
+    timeZone: "Europe/Lisbon",
+  });
+
+  assert.deepEqual(
+    events.map((event) => [event.classDate, event.classTime]),
+    [["2026-07-03", "08:30"]],
+  );
+});
+
+test("cancelled recurrence override removes instance without adding replacement", () => {
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260626T053000Z",
+    "RRULE:FREQ=WEEKLY;COUNT=2",
+    "END:VEVENT",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "RECURRENCE-ID:20260703T053000Z",
+    "SUMMARY:Crossfit",
+    "STATUS:CANCELLED",
+    "DTSTART:20260703T053000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const events = expandCalendarEvents({
+    icsText: ics,
+    now: new Date("2026-06-29T00:00:00Z"),
+    lookaheadHours: 120,
+    calendarEventNames: ["Crossfit"],
+    timeZone: "Europe/Lisbon",
+  });
+
+  assert.deepEqual(events, []);
+});
+
+test("moved recurring instance dispatches enroll at new time and unenrolls stale slot", async () => {
+  const staleKey = "regybox:v1:calendar:weekly-class:2026-07-03T06:30:00.000Z";
+  const kv = makeKv(
+    new Map([
+      [
+        staleKey,
+        JSON.stringify({
+          state: "enrolled",
+          classDate: "2026-07-03",
+          classTime: "06:30",
+          classType: "WOD",
+          calendarEventName: "Crossfit",
+          calendarFingerprint: "weekly-class:2026-07-03T06:30:00.000Z",
+        }),
+      ],
+    ]),
+  );
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260626T053000Z",
+    "RRULE:FREQ=WEEKLY;COUNT=2",
+    "EXDATE:20260703T053000Z",
+    "END:VEVENT",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "RECURRENCE-ID:20260703T053000Z",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260703T073000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const plan = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: ics,
+    now: new Date("2026-06-30T12:00:00Z"),
+  });
+
+  assert.deepEqual(
+    plan.dispatches.map((dispatch) => [
+      dispatch.operation,
+      dispatch.inputs["class-date"],
+      dispatch.inputs["class-time"],
+    ]),
+    [
+      ["enroll", "2026-07-03", "08:30"],
+      ["unenroll", "2026-07-03", "06:30"],
+    ],
+  );
+});
+
 test("unsupported monthly RRULEs are ignored", () => {
   const ics = [
     "BEGIN:VCALENDAR",

--- a/cloudflare/regybox-scheduler/test/worker.test.js
+++ b/cloudflare/regybox-scheduler/test/worker.test.js
@@ -781,6 +781,39 @@ test("cancelled recurrence override without dtstart still removes instance", () 
   assert.deepEqual(events, []);
 });
 
+test("malformed recurrence-id on one override does not abort expansion", () => {
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260626T053000Z",
+    "RRULE:FREQ=WEEKLY;COUNT=2",
+    "END:VEVENT",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "RECURRENCE-ID:not-a-valid-date",
+    "STATUS:CANCELLED",
+    "END:VEVENT",
+    "BEGIN:VEVENT",
+    "UID:weekly-class",
+    "RECURRENCE-ID:20260703T053000Z",
+    "STATUS:CANCELLED",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const events = expandCalendarEvents({
+    icsText: ics,
+    now: new Date("2026-06-29T00:00:00Z"),
+    lookaheadHours: 120,
+    calendarEventNames: ["Crossfit"],
+    timeZone: "Europe/Lisbon",
+  });
+
+  assert.deepEqual(events, []);
+});
+
 test("buildPlan unenrolls cancelled recurring instance without new enroll", async () => {
   const staleKey = "regybox:v1:calendar:weekly-class:2026-07-03T06:30:00.000Z";
   const kv = makeKv(

--- a/cloudflare/regybox-scheduler/worker.js
+++ b/cloudflare/regybox-scheduler/worker.js
@@ -231,18 +231,26 @@ function masterMatchesCalendarEvent(props, normalizedNames) {
   );
 }
 
+function tryParseDate(value) {
+  if (!value) {
+    return null;
+  }
+  try {
+    const parsed = parseDate(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  } catch {
+    return null;
+  }
+}
+
 function excludedRecurrenceInstants(overrides) {
   return overrides
-    .map((props) => parseDate(recurrenceIdValue(props)))
-    .filter((instant) => !Number.isNaN(instant.getTime()));
+    .map((props) => tryParseDate(recurrenceIdValue(props)))
+    .filter((instant) => instant !== null);
 }
 
 function overrideStartInstant(props) {
-  if (!props.DTSTART) {
-    return null;
-  }
-  const parsed = parseDate(props.DTSTART);
-  return Number.isNaN(parsed.getTime()) ? null : parsed;
+  return tryParseDate(props.DTSTART);
 }
 
 function appendOverrideInstances({

--- a/cloudflare/regybox-scheduler/worker.js
+++ b/cloudflare/regybox-scheduler/worker.js
@@ -211,6 +211,44 @@ function eventDetails(props, start, timeZone) {
   };
 }
 
+function isCancelledEvent(props) {
+  return String(props.STATUS ?? "").trim().toUpperCase() === "CANCELLED";
+}
+
+function recurrenceIdValue(props) {
+  return props["RECURRENCE-ID"] ?? null;
+}
+
+function isRecurrenceOverride(props) {
+  return recurrenceIdValue(props) !== null;
+}
+
+function matchingCalendarEvent(props, normalizedNames) {
+  return (
+    props.DTSTART &&
+    props.SUMMARY &&
+    normalizedNames.has(props.SUMMARY.trim().toLowerCase())
+  );
+}
+
+function excludedRecurrenceInstants(overrides) {
+  return overrides
+    .map((props) => parseDate(recurrenceIdValue(props)))
+    .filter((instant) => !Number.isNaN(instant.getTime()));
+}
+
+function appendOverrideInstances({ events, overrides, now, windowEnd, timeZone }) {
+  for (const props of overrides) {
+    if (isCancelledEvent(props)) {
+      continue;
+    }
+    const overrideStart = parseDate(props.DTSTART);
+    if (overrideStart >= now && overrideStart < windowEnd) {
+      events.push(eventDetails(props, overrideStart, timeZone));
+    }
+  }
+}
+
 export function expandCalendarEvents({
   icsText,
   now,
@@ -221,16 +259,37 @@ export function expandCalendarEvents({
   validateCalendarEventNames(calendarEventNames);
   const normalizedNames = new Set(calendarEventNames.map((name) => name.toLowerCase()));
   const windowEnd = new Date(now.getTime() + lookaheadHours * 60 * 60 * 1000);
-  const events = [];
-  for (const props of parseEvents(icsText)) {
-    if (!props.DTSTART || !props.SUMMARY) {
+  const parsedEvents = parseEvents(icsText).filter((props) =>
+    matchingCalendarEvent(props, normalizedNames),
+  );
+  const overridesByUid = new Map();
+  const masterEvents = [];
+
+  for (const props of parsedEvents) {
+    if (isRecurrenceOverride(props)) {
+      const uid = props.UID;
+      if (!uid) {
+        continue;
+      }
+      const overrides = overridesByUid.get(uid) ?? [];
+      overrides.push(props);
+      overridesByUid.set(uid, overrides);
       continue;
     }
-    if (!normalizedNames.has(props.SUMMARY.trim().toLowerCase())) {
-      continue;
+    masterEvents.push(props);
+  }
+
+  const events = [];
+  for (const props of masterEvents) {
+    const overrides = props.UID ? (overridesByUid.get(props.UID) ?? []) : [];
+    if (props.UID) {
+      overridesByUid.delete(props.UID);
     }
     const start = parseDate(props.DTSTART);
-    const excludedDates = parseDateList(props.EXDATE);
+    const excludedDates = [
+      ...parseDateList(props.EXDATE),
+      ...excludedRecurrenceInstants(overrides),
+    ];
     const starts = props.RRULE
       ? recurrenceInstances(start, parseRrule(props.RRULE), now, windowEnd, excludedDates)
       : [start].filter(
@@ -242,7 +301,13 @@ export function expandCalendarEvents({
     events.push(
       ...starts.map((instanceStart) => eventDetails(props, instanceStart, timeZone)),
     );
+    appendOverrideInstances({ events, overrides, now, windowEnd, timeZone });
   }
+
+  for (const overrides of overridesByUid.values()) {
+    appendOverrideInstances({ events, overrides, now, windowEnd, timeZone });
+  }
+
   return events.sort((left, right) => left.start - right.start);
 }
 

--- a/cloudflare/regybox-scheduler/worker.js
+++ b/cloudflare/regybox-scheduler/worker.js
@@ -191,13 +191,13 @@ function zonedDateParts(date, timeZone) {
   );
 }
 
-function eventDetails(props, start, timeZone) {
-  const uid = props.UID || `${props.SUMMARY}:${start.toISOString()}`;
+function eventDetails(props, start, timeZone, summary = props.SUMMARY) {
+  const uid = props.UID || `${summary}:${start.toISOString()}`;
   const fingerprint = `${uid}:${start.toISOString()}`;
   const isUtc = props.DTSTART.trim().endsWith("Z");
   const zoned = isUtc ? zonedDateParts(start, timeZone) : null;
   return {
-    summary: props.SUMMARY,
+    summary,
     uid,
     start,
     classDate: zoned
@@ -223,7 +223,7 @@ function isRecurrenceOverride(props) {
   return recurrenceIdValue(props) !== null;
 }
 
-function matchingCalendarEvent(props, normalizedNames) {
+function masterMatchesCalendarEvent(props, normalizedNames) {
   return (
     props.DTSTART &&
     props.SUMMARY &&
@@ -237,14 +237,35 @@ function excludedRecurrenceInstants(overrides) {
     .filter((instant) => !Number.isNaN(instant.getTime()));
 }
 
-function appendOverrideInstances({ events, overrides, now, windowEnd, timeZone }) {
+function overrideStartInstant(props) {
+  if (!props.DTSTART) {
+    return null;
+  }
+  const parsed = parseDate(props.DTSTART);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function appendOverrideInstances({
+  events,
+  overrides,
+  now,
+  windowEnd,
+  timeZone,
+  masterSummary,
+}) {
   for (const props of overrides) {
     if (isCancelledEvent(props)) {
       continue;
     }
-    const overrideStart = parseDate(props.DTSTART);
+    const overrideStart = overrideStartInstant(props);
+    if (!overrideStart) {
+      continue;
+    }
+    // Match recurrenceInstances: only emit overrides inside the lookahead window.
     if (overrideStart >= now && overrideStart < windowEnd) {
-      events.push(eventDetails(props, overrideStart, timeZone));
+      events.push(
+        eventDetails(props, overrideStart, timeZone, props.SUMMARY ?? masterSummary),
+      );
     }
   }
 }
@@ -259,13 +280,10 @@ export function expandCalendarEvents({
   validateCalendarEventNames(calendarEventNames);
   const normalizedNames = new Set(calendarEventNames.map((name) => name.toLowerCase()));
   const windowEnd = new Date(now.getTime() + lookaheadHours * 60 * 60 * 1000);
-  const parsedEvents = parseEvents(icsText).filter((props) =>
-    matchingCalendarEvent(props, normalizedNames),
-  );
   const overridesByUid = new Map();
   const masterEvents = [];
 
-  for (const props of parsedEvents) {
+  for (const props of parseEvents(icsText)) {
     if (isRecurrenceOverride(props)) {
       const uid = props.UID;
       if (!uid) {
@@ -276,7 +294,16 @@ export function expandCalendarEvents({
       overridesByUid.set(uid, overrides);
       continue;
     }
-    masterEvents.push(props);
+    if (masterMatchesCalendarEvent(props, normalizedNames)) {
+      masterEvents.push(props);
+    }
+  }
+
+  const trackedUids = new Set(masterEvents.map((props) => props.UID).filter(Boolean));
+  for (const uid of overridesByUid.keys()) {
+    if (!trackedUids.has(uid)) {
+      overridesByUid.delete(uid);
+    }
   }
 
   const events = [];
@@ -301,11 +328,14 @@ export function expandCalendarEvents({
     events.push(
       ...starts.map((instanceStart) => eventDetails(props, instanceStart, timeZone)),
     );
-    appendOverrideInstances({ events, overrides, now, windowEnd, timeZone });
-  }
-
-  for (const overrides of overridesByUid.values()) {
-    appendOverrideInstances({ events, overrides, now, windowEnd, timeZone });
+    appendOverrideInstances({
+      events,
+      overrides,
+      now,
+      windowEnd,
+      timeZone,
+      masterSummary: props.SUMMARY,
+    });
   }
 
   return events.sort((left, right) => left.start - right.start);


### PR DESCRIPTION
- handle RECURRENCE-ID overrides when expanding ICS events
- exclude cancelled overrides and enroll at the rescheduled time
- add worker tests for moved and cancelled recurrence instances
- ignore node_modules in git

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar scheduling now respects moved recurring events, so updated occurrences appear at the revised time.
  * Cancelled recurring instances are now omitted from scheduled results.

* **Bug Fixes**
  * Improved handling of recurring calendar overrides so changes to individual instances are reflected correctly.
  * Scheduling updates now better reconcile existing enrollments when a recurring event shifts, helping avoid stale entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->