### PR TITLE
chore: inject worker vars from env at deploy time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,4 @@ tmp/
 temp/
 node_modules/
 .worktrees/
+cloudflare/regybox-scheduler/.wrangler.deploy.jsonc

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 JOBS ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 MAKEFLAGS += -j$(JOBS) --output-sync=target
 
-.PHONY: check lint typecheck test test-python test-worker test-strict-roundtrip test-roundtrip-verbose fix repl \
+.PHONY: check lint typecheck test test-python test-worker deploy-worker test-strict-roundtrip test-roundtrip-verbose fix repl \
         lint-ruff lint-ruff-format lint-docfmt lint-bandit lint-yamllint lint-rumdl lint-tombi \
         type-ty type-pyright
 
@@ -57,6 +57,9 @@ test-python:
 
 test-worker:
 	cd cloudflare/regybox-scheduler && npm test
+
+deploy-worker:
+	cd cloudflare/regybox-scheduler && npm run deploy
 
 ########
 # Fixes (keep sequential to avoid races)

--- a/README.md
+++ b/README.md
@@ -257,7 +257,22 @@ From the repository root you can also run `make deploy-worker` after exporting
 
 `npm run deploy` renders `.wrangler.deploy.jsonc` from `wrangler.jsonc` and deploys with
 Wrangler. The committed `wrangler.jsonc` keeps a placeholder namespace ID so the repository stays
-portable.
+portable. Worker text variables are not committed: set them in the Cloudflare dashboard (step 6) or
+provide them as environment variables when deploying. `keep_vars` is enabled so deploys update
+worker code without removing dashboard variables that are not present in the rendered config.
+
+Optional deploy-time text variables (for example in `.env` locally or Workers Builds secrets):
+
+- `CALENDAR_EVENT_NAMES`
+- `CLASS_TYPE`
+- `GITHUB_OWNER`
+- `GITHUB_REPO`
+- `GITHUB_WORKFLOW`
+- `GITHUB_REF`
+- `LOOKAHEAD_HOURS`
+- `TIMEZONE`
+
+Keep `GITHUB_TOKEN` and `CALENDAR_URL` as Worker secrets in the dashboard, not in `wrangler.jsonc`.
 
 ##### Cloudflare Workers Builds (Git Deploys)
 
@@ -267,12 +282,14 @@ If the Worker is connected to GitHub, set the **Deploy command** to:
 npm run deploy
 ```
 
-In **Settings → Builds → Variables and secrets**, add a secret:
+In **Settings → Builds → Variables and secrets**, add secrets as needed:
 
-- `CF_KV_NAMESPACE_ID` — the KV namespace ID from step 2.
+- `CF_KV_NAMESPACE_ID` — required; the KV namespace ID from step 2.
+- Any optional deploy-time text variables listed above if you want Git deploys to set them instead
+  of using only the dashboard.
 
 Workers Builds injects build secrets as environment variables, so `npm run deploy` can render the
-Wrangler config at deploy time without committing your namespace ID.
+Wrangler config at deploy time without committing your namespace ID or account-specific settings.
 
 #### 6. Add Worker Variables and Secrets
 

--- a/README.md
+++ b/README.md
@@ -244,8 +244,35 @@ The Worker needs a GitHub token that can call the workflow dispatch endpoint.
    repository into the `worker.js` tab.
 8. Click **Deploy**.
 
-If you deploy with Wrangler instead, copy `cloudflare/regybox-scheduler/wrangler.jsonc`, replace
-`replace-with-your-kv-namespace-id`, and run the Worker package from that directory.
+If you deploy with Wrangler instead, set `CF_KV_NAMESPACE_ID` to the KV namespace ID from step 2
+and run the Worker package from [`cloudflare/regybox-scheduler`](cloudflare/regybox-scheduler):
+
+```bash
+cd cloudflare/regybox-scheduler
+CF_KV_NAMESPACE_ID=<your-kv-namespace-id> npm run deploy
+```
+
+From the repository root you can also run `make deploy-worker` after exporting
+`CF_KV_NAMESPACE_ID`.
+
+`npm run deploy` renders `.wrangler.deploy.jsonc` from `wrangler.jsonc` and deploys with
+Wrangler. The committed `wrangler.jsonc` keeps a placeholder namespace ID so the repository stays
+portable.
+
+##### Cloudflare Workers Builds (Git Deploys)
+
+If the Worker is connected to GitHub, set the **Deploy command** to:
+
+```bash
+npm run deploy
+```
+
+In **Settings → Builds → Variables and secrets**, add a secret:
+
+- `CF_KV_NAMESPACE_ID` — the KV namespace ID from step 2.
+
+Workers Builds injects build secrets as environment variables, so `npm run deploy` can render the
+Wrangler config at deploy time without committing your namespace ID.
 
 #### 6. Add Worker Variables and Secrets
 

--- a/cloudflare/regybox-scheduler/package.json
+++ b/cloudflare/regybox-scheduler/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "deploy": "node scripts/render-wrangler-config.mjs && npx wrangler deploy -c .wrangler.deploy.jsonc"
   }
 }

--- a/cloudflare/regybox-scheduler/scripts/render-wrangler-config.mjs
+++ b/cloudflare/regybox-scheduler/scripts/render-wrangler-config.mjs
@@ -5,6 +5,17 @@ import { fileURLToPath } from "node:url";
 const PLACEHOLDER = "replace-with-your-kv-namespace-id";
 const OUTPUT_FILE = ".wrangler.deploy.jsonc";
 
+export const WORKER_VAR_KEYS = [
+  "CALENDAR_EVENT_NAMES",
+  "CLASS_TYPE",
+  "GITHUB_OWNER",
+  "GITHUB_REF",
+  "GITHUB_REPO",
+  "GITHUB_WORKFLOW",
+  "LOOKAHEAD_HOURS",
+  "TIMEZONE",
+];
+
 export function loadRepoDotEnv(repoRoot) {
   const envPath = resolve(repoRoot, ".env");
   try {
@@ -35,28 +46,51 @@ export function loadRepoDotEnv(repoRoot) {
   }
 }
 
-export function renderWranglerConfig(templateText, namespaceId) {
+export function stripJsoncComments(text) {
+  return text.replace(/\/\/.*$/gm, "");
+}
+
+export function collectWorkerVars(env) {
+  const vars = {};
+  for (const key of WORKER_VAR_KEYS) {
+    const value = env[key]?.trim();
+    if (value) {
+      vars[key] = value;
+    }
+  }
+  return vars;
+}
+
+export function renderWranglerConfig(templateText, namespaceId, env = {}) {
   const id = namespaceId?.trim();
   if (!id) {
     throw new Error("CF_KV_NAMESPACE_ID is required to deploy the scheduler worker.");
   }
-  if (!templateText.includes(PLACEHOLDER)) {
+  const config = JSON.parse(stripJsoncComments(templateText));
+  const namespace = config.kv_namespaces?.[0];
+  if (!namespace || namespace.id !== PLACEHOLDER) {
     throw new Error(`wrangler.jsonc is missing placeholder ${PLACEHOLDER}.`);
   }
-  return templateText.replace(PLACEHOLDER, id);
+  namespace.id = id;
+  const vars = collectWorkerVars(env);
+  if (Object.keys(vars).length > 0) {
+    config.vars = vars;
+  } else {
+    delete config.vars;
+  }
+  return `${JSON.stringify(config, null, 2)}\n`;
 }
 
 function main() {
   const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
   const repoRoot = resolve(packageRoot, "../..");
-  if (!process.env.CF_KV_NAMESPACE_ID?.trim()) {
-    loadRepoDotEnv(repoRoot);
-  }
+  loadRepoDotEnv(repoRoot);
   const templatePath = resolve(packageRoot, "wrangler.jsonc");
   const outputPath = resolve(packageRoot, OUTPUT_FILE);
   const rendered = renderWranglerConfig(
     readFileSync(templatePath, "utf8"),
     process.env.CF_KV_NAMESPACE_ID,
+    process.env,
   );
   writeFileSync(outputPath, rendered);
 }

--- a/cloudflare/regybox-scheduler/scripts/render-wrangler-config.mjs
+++ b/cloudflare/regybox-scheduler/scripts/render-wrangler-config.mjs
@@ -1,0 +1,66 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PLACEHOLDER = "replace-with-your-kv-namespace-id";
+const OUTPUT_FILE = ".wrangler.deploy.jsonc";
+
+export function loadRepoDotEnv(repoRoot) {
+  const envPath = resolve(repoRoot, ".env");
+  try {
+    const content = readFileSync(envPath, "utf8");
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) {
+        continue;
+      }
+      const separator = trimmed.indexOf("=");
+      if (separator === -1) {
+        continue;
+      }
+      const key = trimmed.slice(0, separator).trim();
+      let value = trimmed.slice(separator + 1).trim();
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in process.env)) {
+        process.env[key] = value;
+      }
+    }
+  } catch {
+    // .env is optional when deploy variables are already exported
+  }
+}
+
+export function renderWranglerConfig(templateText, namespaceId) {
+  const id = namespaceId?.trim();
+  if (!id) {
+    throw new Error("CF_KV_NAMESPACE_ID is required to deploy the scheduler worker.");
+  }
+  if (!templateText.includes(PLACEHOLDER)) {
+    throw new Error(`wrangler.jsonc is missing placeholder ${PLACEHOLDER}.`);
+  }
+  return templateText.replace(PLACEHOLDER, id);
+}
+
+function main() {
+  const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const repoRoot = resolve(packageRoot, "../..");
+  if (!process.env.CF_KV_NAMESPACE_ID?.trim()) {
+    loadRepoDotEnv(repoRoot);
+  }
+  const templatePath = resolve(packageRoot, "wrangler.jsonc");
+  const outputPath = resolve(packageRoot, OUTPUT_FILE);
+  const rendered = renderWranglerConfig(
+    readFileSync(templatePath, "utf8"),
+    process.env.CF_KV_NAMESPACE_ID,
+  );
+  writeFileSync(outputPath, rendered);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/cloudflare/regybox-scheduler/test/render-wrangler-config.test.mjs
+++ b/cloudflare/regybox-scheduler/test/render-wrangler-config.test.mjs
@@ -4,18 +4,50 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { loadRepoDotEnv, renderWranglerConfig } from "../scripts/render-wrangler-config.mjs";
+import {
+  collectWorkerVars,
+  loadRepoDotEnv,
+  renderWranglerConfig,
+} from "../scripts/render-wrangler-config.mjs";
 
 const template = `{
+  "keep_vars": true,
   "kv_namespaces": [
     { "binding": "REGYBOX_STATE", "id": "replace-with-your-kv-namespace-id" }
   ]
 }`;
 
 test("renderWranglerConfig substitutes the kv namespace id", () => {
-  const rendered = renderWranglerConfig(template, "test-kv-namespace-id");
-  assert.match(rendered, /test-kv-namespace-id/);
-  assert.doesNotMatch(rendered, /replace-with-your-kv-namespace-id/);
+  const rendered = JSON.parse(renderWranglerConfig(template, "test-kv-namespace-id"));
+  assert.equal(rendered.kv_namespaces[0].id, "test-kv-namespace-id");
+  assert.equal(rendered.vars, undefined);
+});
+
+test("renderWranglerConfig injects worker vars from env", () => {
+  const rendered = JSON.parse(
+    renderWranglerConfig(template, "test-kv-namespace-id", {
+      GITHUB_OWNER: "example-owner",
+      CLASS_TYPE: "WOD",
+    }),
+  );
+  assert.deepEqual(rendered.vars, {
+    GITHUB_OWNER: "example-owner",
+    CLASS_TYPE: "WOD",
+  });
+});
+
+test("collectWorkerVars ignores empty values", () => {
+  assert.deepEqual(
+    collectWorkerVars({
+      GITHUB_OWNER: " example-owner ",
+      GITHUB_REPO: "   ",
+      LOOKAHEAD_HOURS: "73",
+    }),
+    {
+      GITHUB_OWNER: "example-owner",
+      LOOKAHEAD_HOURS: "73",
+    },
+  );
 });
 
 test("renderWranglerConfig rejects a missing namespace id", () => {

--- a/cloudflare/regybox-scheduler/test/render-wrangler-config.test.mjs
+++ b/cloudflare/regybox-scheduler/test/render-wrangler-config.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { loadRepoDotEnv, renderWranglerConfig } from "../scripts/render-wrangler-config.mjs";
+
+const template = `{
+  "kv_namespaces": [
+    { "binding": "REGYBOX_STATE", "id": "replace-with-your-kv-namespace-id" }
+  ]
+}`;
+
+test("renderWranglerConfig substitutes the kv namespace id", () => {
+  const rendered = renderWranglerConfig(template, "test-kv-namespace-id");
+  assert.match(rendered, /test-kv-namespace-id/);
+  assert.doesNotMatch(rendered, /replace-with-your-kv-namespace-id/);
+});
+
+test("renderWranglerConfig rejects a missing namespace id", () => {
+  assert.throws(
+    () => renderWranglerConfig(template, ""),
+    /CF_KV_NAMESPACE_ID is required/,
+  );
+});
+
+test("loadRepoDotEnv reads cf kv namespace id from repo .env", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "regybox-env-"));
+  writeFileSync(join(repoRoot, ".env"), "CF_KV_NAMESPACE_ID=test-namespace-id\n");
+  const previous = process.env.CF_KV_NAMESPACE_ID;
+  delete process.env.CF_KV_NAMESPACE_ID;
+  try {
+    loadRepoDotEnv(repoRoot);
+    assert.equal(process.env.CF_KV_NAMESPACE_ID, "test-namespace-id");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CF_KV_NAMESPACE_ID;
+    } else {
+      process.env.CF_KV_NAMESPACE_ID = previous;
+    }
+  }
+});

--- a/cloudflare/regybox-scheduler/wrangler.jsonc
+++ b/cloudflare/regybox-scheduler/wrangler.jsonc
@@ -2,7 +2,9 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "regybox-scheduler",
   "main": "worker.js",
-  "compatibility_date": "2026-06-18",
+  "compatibility_date": "2026-06-17",
+  "preview_urls": false,
+  "keep_vars": true,
   "kv_namespaces": [
     {
       "binding": "REGYBOX_STATE",
@@ -11,5 +13,10 @@
   ],
   "triggers": {
     "crons": ["28,58 * * * *"]
+  },
+  "observability": {
+    "logs": {
+      "enabled": true
+    }
   }
 }


### PR DESCRIPTION
## Summary
- keep personal worker settings out of committed wrangler.jsonc
- render optional text vars from env or workers builds secrets at deploy
- enable keep_vars so dashboard variables survive deploys without env values
- document deploy-time variables and workers builds setup in readme

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test`