### PR TITLE
fix: reduce scheduler work per cron run

### DIFF
--- a/cloudflare/regybox-scheduler/test/worker.test.js
+++ b/cloudflare/regybox-scheduler/test/worker.test.js
@@ -19,9 +19,12 @@ const baseEnv = {
 
 function makeKv(existing = new Map()) {
   const writes = [];
+  const gets = [];
   return {
     writes,
+    gets,
     async get(key) {
+      gets.push(key);
       return existing.get(key) ?? null;
     },
     async put(key, value) {
@@ -33,6 +36,26 @@ function makeKv(existing = new Map()) {
         keys: [...existing.keys()]
           .filter((name) => name.startsWith(prefix))
           .map((name) => ({ name })),
+      };
+    },
+  };
+}
+
+function makePaginatedKv(pages, values) {
+  return {
+    async get(key) {
+      return values.get(key) ?? null;
+    },
+    async list({ prefix, cursor }) {
+      const pageIndex = cursor ? Number.parseInt(cursor, 10) : 0;
+      const keys = pages[pageIndex]
+        .filter((name) => name.startsWith(prefix))
+        .map((name) => ({ name }));
+      const nextPageIndex = pageIndex + 1;
+      return {
+        keys,
+        list_complete: nextPageIndex >= pages.length,
+        cursor: String(nextPageIndex),
       };
     },
   };
@@ -177,6 +200,73 @@ test("existing KV entry with matching calendar event skips dispatch", async () =
   });
 
   assert.deepEqual(plan.dispatches, []);
+});
+
+test("buildPlan reuses listed KV values for active event cache checks", async () => {
+  const key = "regybox:v1:calendar:one-class:2026-06-18T06:30:00.000Z";
+  const kv = makeKv(new Map([[key, JSON.stringify({ state: "enrolled" })]]));
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:one-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260618T063000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: ics,
+    now: new Date("2026-06-18T00:00:00Z"),
+  });
+
+  assert.deepEqual(kv.gets, [key]);
+});
+
+test("buildPlan sweeps stale enrolled entries across paginated KV listings", async () => {
+  const firstPageKey = "regybox:v1:calendar:old-class:2026-06-18T06:30:00.000Z";
+  const secondPageKey = "regybox:v1:calendar:old-class:2026-06-19T06:30:00.000Z";
+  const kv = makePaginatedKv(
+    [[firstPageKey], [secondPageKey]],
+    new Map([
+      [
+        firstPageKey,
+        JSON.stringify({
+          state: "enrolled",
+          classDate: "2026-06-18",
+          classTime: "06:30",
+          classType: "WOD",
+          calendarEventName: "Crossfit",
+          calendarFingerprint: "old-class:2026-06-18T06:30:00.000Z",
+        }),
+      ],
+      [
+        secondPageKey,
+        JSON.stringify({
+          state: "enrolled",
+          classDate: "2026-06-19",
+          classTime: "06:30",
+          classType: "WOD",
+          calendarEventName: "Crossfit",
+          calendarFingerprint: "old-class:2026-06-19T06:30:00.000Z",
+        }),
+      ],
+    ]),
+  );
+
+  const plan = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: "BEGIN:VCALENDAR\r\nEND:VCALENDAR",
+    now: new Date("2026-06-18T00:00:00Z"),
+  });
+
+  assert.deepEqual(
+    plan.dispatches.map((dispatch) => dispatch.inputs["class-date"]),
+    ["2026-06-18", "2026-06-19"],
+  );
 });
 
 test("not-open KV entry skips dispatch when opening is far away and recently checked", async () => {

--- a/cloudflare/regybox-scheduler/worker.js
+++ b/cloudflare/regybox-scheduler/worker.js
@@ -174,28 +174,30 @@ function pad(value) {
   return String(value).padStart(2, "0");
 }
 
-function zonedDateParts(date, timeZone) {
-  return Object.fromEntries(
-    new Intl.DateTimeFormat("en-GB", {
-      timeZone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      hourCycle: "h23",
-    })
-      .formatToParts(date)
-      .filter((part) => part.type !== "literal")
-      .map((part) => [part.type, part.value]),
-  );
+function createZonedDateParts(timeZone) {
+  const formatter = new Intl.DateTimeFormat("en-GB", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+  return (date) =>
+    Object.fromEntries(
+      formatter
+        .formatToParts(date)
+        .filter((part) => part.type !== "literal")
+        .map((part) => [part.type, part.value]),
+    );
 }
 
-function eventDetails(props, start, timeZone, summary = props.SUMMARY) {
+function eventDetails(props, start, zonedDateParts, summary = props.SUMMARY) {
   const uid = props.UID || `${summary}:${start.toISOString()}`;
   const fingerprint = `${uid}:${start.toISOString()}`;
   const isUtc = props.DTSTART.trim().endsWith("Z");
-  const zoned = isUtc ? zonedDateParts(start, timeZone) : null;
+  const zoned = isUtc ? zonedDateParts(start) : null;
   return {
     summary,
     uid,
@@ -258,7 +260,7 @@ function appendOverrideInstances({
   overrides,
   now,
   windowEnd,
-  timeZone,
+  zonedDateParts,
   masterSummary,
 }) {
   for (const props of overrides) {
@@ -272,7 +274,7 @@ function appendOverrideInstances({
     // Match recurrenceInstances: only emit overrides inside the lookahead window.
     if (overrideStart >= now && overrideStart < windowEnd) {
       events.push(
-        eventDetails(props, overrideStart, timeZone, props.SUMMARY ?? masterSummary),
+        eventDetails(props, overrideStart, zonedDateParts, props.SUMMARY ?? masterSummary),
       );
     }
   }
@@ -288,6 +290,7 @@ export function expandCalendarEvents({
   validateCalendarEventNames(calendarEventNames);
   const normalizedNames = new Set(calendarEventNames.map((name) => name.toLowerCase()));
   const windowEnd = new Date(now.getTime() + lookaheadHours * 60 * 60 * 1000);
+  const zonedDateParts = createZonedDateParts(timeZone);
   const overridesByUid = new Map();
   const masterEvents = [];
 
@@ -334,14 +337,14 @@ export function expandCalendarEvents({
             !excludedDates.some((excluded) => sameUtcInstant(excluded, candidate)),
         );
     events.push(
-      ...starts.map((instanceStart) => eventDetails(props, instanceStart, timeZone)),
+      ...starts.map((instanceStart) => eventDetails(props, instanceStart, zonedDateParts)),
     );
     appendOverrideInstances({
       events,
       overrides,
       now,
       windowEnd,
-      timeZone,
+      zonedDateParts,
       masterSummary: props.SUMMARY,
     });
   }
@@ -353,8 +356,14 @@ async function listKvEntries(kv) {
   if (typeof kv.list !== "function") {
     return [];
   }
-  const response = await kv.list({ prefix: KV_PREFIX });
-  return response.keys ?? [];
+  const keys = [];
+  let cursor;
+  do {
+    const response = await kv.list({ prefix: KV_PREFIX, cursor });
+    keys.push(...(response.keys ?? []));
+    cursor = response.list_complete === false ? response.cursor : undefined;
+  } while (cursor);
+  return keys;
 }
 
 async function readJson(kv, key) {
@@ -452,6 +461,7 @@ export async function buildPlan({ env, kv, icsText, now = new Date() }) {
   const cachedKvEntries = await Promise.all(
     kvEntries.map(async ({ name }) => [name, await readJson(kv, name)]),
   );
+  const cachedByName = new Map(cachedKvEntries);
   const enrolledSlots = new Set(
     cachedKvEntries
       .filter(([, cached]) => cached?.state === "enrolled" && cachedEventIsFuture(cached, now))
@@ -460,7 +470,12 @@ export async function buildPlan({ env, kv, icsText, now = new Date() }) {
   );
 
   const eventCacheEntries = await Promise.all(
-    events.map(async (event) => [event, await readJson(kv, event.cacheKey)]),
+    events.map(async (event) => [
+      event,
+      cachedByName.has(event.cacheKey)
+        ? cachedByName.get(event.cacheKey)
+        : await readJson(kv, event.cacheKey),
+    ]),
   );
   const plannedEnrollmentSlots = new Set();
 


### PR DESCRIPTION
- reuse cached KV reads for active event checks
- handle paginated scheduler KV listings
- reuse timezone formatter during calendar expansion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar event rendering so time-zone handling is more consistent.
  * Planning now scans all stored entries correctly, including multi-page results, reducing missed items.
  * Cached event data is reused more efficiently, which helps avoid unnecessary lookups and improves reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->