### PR TITLE
fix: refresh closed enrollments every six hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,42 @@ always shows the booking rules currently in effect. Your dashboard values stay i
 place when the Worker is redeployed; in particular, updates do not replace your
 `CLASS_MAP`, cookies, calendar URL, or email settings.
 
+#### Keep the Status Page Private (Recommended)
+
+Use [Cloudflare Access](https://developers.cloudflare.com/workers/configuration/routing/workers-dev/#manage-access-to-workersdev)
+to let only your email address open the status page and incident reports:
+
+1. Open the Worker, then go to **Settings → Domains & Routes**.
+2. Beside `workers.dev`, select **Enable Cloudflare Access**, then **Manage
+   Cloudflare Access**.
+3. Edit the new **Allow** policy. Under **Include**, choose **Emails** and enter
+   only the exact email address that should have access.
+   If `EMAIL_TO` is different and must open emailed incident links, add that
+   exact address too. It must also be able to sign in through a configured
+   identity provider. For a non-account-member address, go to **Zero Trust →
+   Integrations → Identity providers → Add new identity provider →
+   One-time PIN** ([instructions](https://developers.cloudflare.com/cloudflare-one/integrations/identity-providers/one-time-pin/)),
+   or add another provider. Keep **Include → Emails** limited to exact addresses.
+4. Inspect every policy in this Access application. For strict single-user
+   access, keep one exact-email **Allow** policy and remove any other broader
+   **Allow** or **Bypass** policy. A narrow exact-email rule does not override a
+   second policy that grants broader access. Also remove any broader **Include**
+   rule: **Everyone**, **Login Methods → One-time PIN** (which includes all valid
+   email addresses), an email-domain rule such as **Emails ending in**, or
+   **Cloudflare Account Member**. One-time PIN itself is fine as a sign-in method
+   or **Require** rule when **Include → Emails** stays limited to exact addresses.
+   See Cloudflare's
+   [Access policy guide](https://developers.cloudflare.com/cloudflare-one/access-controls/policies/)
+   for details.
+5. Save the changes, then test the `workers.dev` link in a private/incognito
+   window. With one-time PIN sign-in, Cloudflare emails a single-use code only
+   to an address allowed by the policy; for privacy, the screen still says a
+   code was sent when a blocked address tries to sign in.
+
+After this, the status page and incident-report links require the allowed
+identity. The Worker's scheduled checks, enrollment, and cancellation continue
+normally in the background.
+
 ### 4. Turn on Automatic Updates (Recommended)
 
 Step 3 did two things: Cloudflare created a new GitHub repository for your copy

--- a/cloudflare/regybox-scheduler/src/calendar.js
+++ b/cloudflare/regybox-scheduler/src/calendar.js
@@ -1,5 +1,5 @@
 const KV_PREFIX = "regybox:v1:calendar:";
-const NOT_OPEN_REFRESH_MS = 24 * 60 * 60 * 1000;
+const NOT_OPEN_REFRESH_MS = 6 * 60 * 60 * 1000;
 const NOT_OPEN_DISPATCH_WINDOW_MS = 60 * 60 * 1000;
 
 export function normalizeList(value) {

--- a/cloudflare/regybox-scheduler/test/worker.test.js
+++ b/cloudflare/regybox-scheduler/test/worker.test.js
@@ -291,8 +291,8 @@ test("buildPlan sweeps stale enrolled entries across paginated KV listings", asy
   );
 });
 
-test("not-open KV entry skips dispatch when opening is far away and recently checked", async () => {
-  const key = "regybox:v1:calendar:one-class:2026-06-18T05:30:00.000Z";
+test("not-open KV entry skips dispatch before the six-hour refresh boundary", async () => {
+  const key = "regybox:v1:calendar:one-class:2026-06-18T10:30:00.000Z";
   const kv = makeKv(
     new Map([
       [
@@ -300,9 +300,9 @@ test("not-open KV entry skips dispatch when opening is far away and recently che
         JSON.stringify({
           state: "not_open",
           classDate: "2026-06-18",
-          classTime: "06:30",
+          classTime: "11:30",
           classType: "WOD",
-          enrollmentOpensAt: "2026-06-18T05:00:00.000Z",
+          enrollmentOpensAt: "2026-06-18T10:00:00.000Z",
           lastCheckedAt: "2026-06-18T00:00:00.000Z",
         }),
       ],
@@ -313,7 +313,7 @@ test("not-open KV entry skips dispatch when opening is far away and recently che
     "BEGIN:VEVENT",
     "UID:one-class",
     "SUMMARY:Crossfit",
-    "DTSTART:20260618T053000Z",
+    "DTSTART:20260618T103000Z",
     "END:VEVENT",
     "END:VCALENDAR",
   ].join("\r\n");
@@ -322,7 +322,7 @@ test("not-open KV entry skips dispatch when opening is far away and recently che
     env: baseEnv,
     kv,
     icsText: ics,
-    now: new Date("2026-06-18T00:30:00Z"),
+    now: new Date("2026-06-18T05:59:59.999Z"),
   });
 
   assert.deepEqual(plan.dispatches, []);
@@ -441,19 +441,19 @@ test("not-open KV entry dispatches when last check time is invalid", async () =>
   assert.equal(plan.dispatches[0].operation, "enroll");
 });
 
-test("not-open KV entry dispatches when last check is over 24 hours old", async () => {
-  const key = "regybox:v1:calendar:one-class:2026-06-19T05:30:00.000Z";
+test("not-open KV entry dispatches at the six-hour refresh boundary", async () => {
+  const key = "regybox:v1:calendar:one-class:2026-06-18T10:30:00.000Z";
   const kv = makeKv(
     new Map([
       [
         key,
         JSON.stringify({
           state: "not_open",
-          classDate: "2026-06-19",
-          classTime: "06:30",
+          classDate: "2026-06-18",
+          classTime: "11:30",
           classType: "WOD",
-          enrollmentOpensAt: "2026-06-19T05:00:00.000Z",
-          lastCheckedAt: "2026-06-17T00:00:00.000Z",
+          enrollmentOpensAt: "2026-06-18T10:00:00.000Z",
+          lastCheckedAt: "2026-06-18T00:00:00.000Z",
         }),
       ],
     ]),
@@ -463,7 +463,7 @@ test("not-open KV entry dispatches when last check is over 24 hours old", async 
     "BEGIN:VEVENT",
     "UID:one-class",
     "SUMMARY:Crossfit",
-    "DTSTART:20260619T053000Z",
+    "DTSTART:20260618T103000Z",
     "END:VEVENT",
     "END:VCALENDAR",
   ].join("\r\n");
@@ -472,7 +472,7 @@ test("not-open KV entry dispatches when last check is over 24 hours old", async 
     env: baseEnv,
     kv,
     icsText: ics,
-    now: new Date("2026-06-18T00:30:00Z"),
+    now: new Date("2026-06-18T06:00:00Z"),
   });
 
   assert.equal(plan.dispatches.length, 1);


### PR DESCRIPTION
## Summary
- reduce cached not-open refresh interval from 24 hours to 6 hours
- preserve the existing immediate retry window when enrollment is within 60 minutes
- cover both sides of the exact six-hour boundary
- document how to restrict the Worker status page and incident reports to exact email identities with Cloudflare Access

## Verification
- make lint
- make typecheck
- make test (162 Python tests, 154 Worker tests)