### PR TITLE
docs: deemphasize legacy setup options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,12 @@ Automatically enroll in a CrossFit class on the Regybox platform.
 
 Add your classes to your calendar (or delete one to skip a day), and this project
 books and cancels the matching Regybox classes for you, optionally emailing you a
-confirmation. There are three ways to run it — pick one:
+confirmation. Use the [one-click Cloudflare setup](#one-click-cloudflare-setup):
+a Cloudflare Worker checks your calendar every half hour and books classes
+directly, with no fixed schedule to maintain. ([Legacy setup instructions](docs/legacy-setups.md)
+remain available for existing installations.)
 
-1. **[One-click Cloudflare setup](#recommended-one-click-cloudflare-setup)**
-   (recommended): a Cloudflare Worker checks your calendar every half hour and
-   books classes directly. Easiest to set up, no fixed schedule to maintain.
-2. **[GitHub Action with a fixed schedule](docs/legacy-setups.md#alternative-github-action-with-a-fixed-schedule)**:
-   books the same class at the same time every week. No Cloudflare account needed.
-3. **[Cloudflare Worker → GitHub Actions dispatch](docs/legacy-setups.md#advanced-calendar-driven-sync-with-cloudflare-and-github)**
-   (advanced): the original calendar-driven setup, kept for existing users.
-
-The last two are documented in [docs/legacy-setups.md](docs/legacy-setups.md).
-
-## Recommended: One-Click Cloudflare Setup
+## One-Click Cloudflare Setup
 
 Everything runs in a free Cloudflare account that you own: your credentials stay
 with you, and there is no server to maintain. You need a Cloudflare account and a

--- a/docs/legacy-setups.md
+++ b/docs/legacy-setups.md
@@ -2,7 +2,7 @@
 
 These are the original ways to run the Regybox auto-enroller. They keep working and are
 fully supported, but new users should start with the
-[one-click Cloudflare setup](../README.md#recommended-one-click-cloudflare-setup) in the
+[one-click Cloudflare setup](../README.md#one-click-cloudflare-setup) in the
 main README.
 
 ## Alternative: GitHub Action with a Fixed Schedule
@@ -34,7 +34,7 @@ several minutes late, which can matter for classes that fill up quickly.
 
    > [!NOTE]
    > If you want your calendar to drive enrollments and unenrollments, use the
-   > [one-click Cloudflare setup](../README.md#recommended-one-click-cloudflare-setup) instead of a
+   > [one-click Cloudflare setup](../README.md#one-click-cloudflare-setup) instead of a
    > fixed-class GitHub schedule.
 
 3. Add the workflow file at `.github/workflows/regybox.yml` using the example below.
@@ -138,7 +138,7 @@ automatically in the class.
 > [!NOTE]
 > This is the original calendar-driven setup, kept for people who already run it or who want
 > GitHub Actions to perform the enrollment. New users should prefer the
-> [one-click Cloudflare setup](../README.md#recommended-one-click-cloudflare-setup), which does the same
+> [one-click Cloudflare setup](../README.md#one-click-cloudflare-setup), which does the same
 > thing without GitHub tokens or Cloudflare API tokens. The same Worker powers both: if the
 > `GITHUB_TOKEN`, `GITHUB_OWNER`, and `GITHUB_REPO` variables are set it dispatches GitHub
 > Actions as described below; otherwise it books classes itself.


### PR DESCRIPTION
- present the one-click Cloudflare setup as the primary path
- keep legacy instructions available through a quiet side-note link
- update legacy documentation backlinks for the renamed heading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloudflare setup instructions to use the streamlined one-click setup flow.
  * Replaced the previous multi-option setup overview with clearer guidance.
  * Updated legacy setup references to link to the new setup section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->