### PR TITLE
fix(cloudflare): restore reliable enrollment and run traces

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -33,6 +33,9 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
+      - name: Install Worker dependencies
+        working-directory: cloudflare/regybox-scheduler
+        run: bun install --frozen-lockfile
       - name: Test
         run: |
           make test

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ place when the Worker is redeployed; in particular, updates do not replace your
 #### Keep the Status Page Private (Recommended)
 
 Use [Cloudflare Access](https://developers.cloudflare.com/workers/configuration/routing/workers-dev/#manage-access-to-workersdev)
-to let only your email address open the status page and incident reports:
+to let only your email address open the status page, complete run timelines, and
+incident reports. The run history is deliberately sanitized, but it still reveals
+your class schedule and operational history, so protecting it is strongly recommended:
 
 1. Open the Worker, then go to **Settings → Domains & Routes**.
 2. Beside `workers.dev`, select **Enable Cloudflare Access**, then **Manage
@@ -221,16 +223,25 @@ tell you — copy fresh cookie values from regybox.pt and update `PHPSESSID` und
 
 ### Seeing What It's Doing
 
-- **Status page** (the `workers.dev` link): the **Recent activity** section lists the
-  last bookings, cancellations, and failures with timestamps, and **Last run** shows
-  what the most recent half-hourly check did — including "nothing to do".
+- **Status page** (the `workers.dev` link): **Recent runs** links to a GitHub
+  Actions-style chronological timeline for every half-hourly check. Timelines include
+  calendar and cache decisions, session startup, polling and retry waits, enrollment
+  attempts, notifications, and terminal outcomes. Up to 400 summaries and seven days
+  of detail are retained; each trace is capped at 500 events and clearly marked if
+  truncated. **Recent activity** remains a compact list of bookings, cancellations,
+  and failures, and **Last run** preserves the previous summary view.
 - **Failure email link**: opens a read-only incident report containing safe parser and
   operation details. The link works for seven days. Open the status page once after
   deployment so scheduled runs know the Worker's public address; alternatively set
   `STATUS_URL` to that address under **Settings → Variables and Secrets**.
 - **Cloudflare logs**: in the dashboard, open the Worker → **Logs** to see every run
-  (searchable, kept for a few days). Every log line the scheduler writes starts with
-  `regybox:`, for example `regybox: enroll WOD on 2026-07-14 at 06:30 -> success`.
+  (searchable, kept for a few days). Every structured timeline event is also emitted
+  there and starts with `regybox:` plus its run ID, making website and Cloudflare
+  evidence easy to correlate.
+- **Privacy**: run records use allowlisted fields and never retain cookies, headers,
+  raw HTML, calendar URLs or contents, email-bearing event/cache identifiers, query
+  strings, tokens, stack traces, or complete action URLs. Protect the Worker with
+  Cloudflare Access anyway because class names and times are visible by design.
 - **Live tail** (for the technically inclined): `bunx wrangler tail <worker-name>`
   streams runs as they happen.
 

--- a/cloudflare/regybox-scheduler/bun.lock
+++ b/cloudflare/regybox-scheduler/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "regybox-scheduler",
       "dependencies": {
+        "parse5": "^8.0.1",
         "worker-mailer": "^1.1.5",
       },
       "devDependencies": {
@@ -155,6 +156,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
@@ -164,6 +167,8 @@
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "miniflare": ["miniflare@4.20260708.1", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260708.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA=="],
+
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 

--- a/cloudflare/regybox-scheduler/package.json
+++ b/cloudflare/regybox-scheduler/package.json
@@ -8,6 +8,7 @@
     "deploy:manual": "node scripts/render-wrangler-config.mjs && wrangler deploy -c .wrangler.deploy.jsonc"
   },
   "dependencies": {
+    "parse5": "^8.0.1",
     "worker-mailer": "^1.1.5"
   },
   "devDependencies": {

--- a/cloudflare/regybox-scheduler/src/calendar.js
+++ b/cloudflare/regybox-scheduler/src/calendar.js
@@ -1,5 +1,7 @@
 const KV_PREFIX = "regybox:v1:calendar:";
-const NOT_OPEN_REFRESH_MS = 6 * 60 * 60 * 1000;
+// Cron runs at :28 and :58. Refreshing after 5h30 ensures the first eligible
+// cron is never later than six hours after the previous check.
+const NOT_OPEN_REFRESH_MS = 5.5 * 60 * 60 * 1000;
 const NOT_OPEN_DISPATCH_WINDOW_MS = 60 * 60 * 1000;
 
 export function normalizeList(value) {
@@ -609,7 +611,7 @@ function dispatchPayload({ operation, event, cacheKey, cached }) {
   };
 }
 
-export async function buildPlan({ env, kv, icsText, now = new Date() }) {
+export async function buildPlan({ env, kv, icsText, now = new Date(), onTrace = async () => {} }) {
   const lookaheadHours = defaultLookaheadHours(env);
   const classRules = resolveClassRules(env);
   const events = expandCalendarEvents({
@@ -618,6 +620,12 @@ export async function buildPlan({ env, kv, icsText, now = new Date() }) {
     lookaheadHours,
     classRules,
     timeZone: env.TIMEZONE || "Europe/Lisbon",
+  });
+  await onTrace({
+    scope: "calendar",
+    code: "calendar_events_expanded",
+    message: `Found ${events.length} relevant calendar event(s) in the scheduling window`,
+    data: { eventCount: events.length },
   });
   const activeKeys = new Set(events.map((event) => event.cacheKey));
   const activeSlots = new Set(events.map((event) => eventSlotKey(event)).filter(Boolean));
@@ -646,11 +654,55 @@ export async function buildPlan({ env, kv, icsText, now = new Date() }) {
 
   for (const [event, cached] of eventCacheEntries) {
     const slotKey = eventSlotKey(event);
-    if (
+    const cacheAgeMs = cached?.lastCheckedAt
+      ? now.getTime() - (parseOptionalDate(cached.lastCheckedAt)?.getTime() ?? now.getTime())
+      : null;
+    const refreshDueAt = cached?.lastCheckedAt
+      ? new Date(
+          (parseOptionalDate(cached.lastCheckedAt)?.getTime() ?? now.getTime()) +
+            NOT_OPEN_REFRESH_MS,
+        ).toISOString()
+      : null;
+    const openingAt = parseOptionalDate(cached?.enrollmentOpensAt);
+    const refreshDue = cached?.state === "not_open" && cacheAgeMs >= NOT_OPEN_REFRESH_MS;
+    const openingDueSoon = cached?.state === "not_open" && openingAt &&
+      openingAt.getTime() - now.getTime() <= NOT_OPEN_DISPATCH_WINDOW_MS;
+    const shouldDispatch =
       (!cached || (cached.state !== "enrolled" && notOpenShouldDispatch(cached, now))) &&
       !enrolledSlots.has(slotKey) &&
-      !plannedEnrollmentSlots.has(slotKey)
-    ) {
+      !plannedEnrollmentSlots.has(slotKey);
+    let reason;
+    if (!cached) reason = "no_cached_state";
+    else if (cached.state === "enrolled" || enrolledSlots.has(slotKey)) reason = "already_enrolled";
+    else if (plannedEnrollmentSlots.has(slotKey)) reason = "duplicate_slot";
+    else if (refreshDue) reason = "forced_refresh_due";
+    else if (openingDueSoon) reason = "opening_within_dispatch_window";
+    else if (cached.state === "not_open") reason = "cached_not_open_not_due";
+    else reason = "state_requires_check";
+    const ageText = Number.isFinite(cacheAgeMs)
+      ? `${Math.floor(cacheAgeMs / 3_600_000)}h${String(Math.floor((cacheAgeMs % 3_600_000) / 60_000)).padStart(2, "0")}m`
+      : null;
+    await onTrace({
+      scope: "calendar",
+      code: shouldDispatch ? "calendar_event_scheduled" : "calendar_event_skipped",
+      message: refreshDue
+        ? `Cached not_open is ${ageText} old; forced refresh is due`
+        : shouldDispatch
+          ? `Scheduled enrollment check for ${event.classType} on ${event.classDate} at ${event.classTime}`
+          : `Skipped ${event.classType} on ${event.classDate} at ${event.classTime} (${reason})`,
+      data: {
+        classDate: event.classDate,
+        classTime: event.classTime,
+        classType: event.classType,
+        cacheState: cached?.state,
+        cacheAgeMs,
+        enrollmentOpensAt: cached?.enrollmentOpensAt,
+        refreshDueAt,
+        decision: shouldDispatch ? "dispatch" : "skip",
+        reason,
+      },
+    });
+    if (shouldDispatch) {
       dispatches.push(
         dispatchPayload({
           operation: "enroll",

--- a/cloudflare/regybox-scheduler/src/executor.js
+++ b/cloudflare/regybox-scheduler/src/executor.js
@@ -1,6 +1,6 @@
 import { buildFailureFingerprint, errorPayload } from "./failures.js";
 import { notifyFailure, notifyResult } from "./notify.js";
-import { createRegyboxClient, runOperation } from "./regybox.js";
+import { UnparseableError, createRegyboxClient, runOperation } from "./regybox.js";
 import { recordIncident, resolveStatusUrl } from "./incidents.js";
 
 const LAST_RUN_KEY = "regybox:v1:last_run";
@@ -9,6 +9,8 @@ const LAST_RUN_TTL_SECONDS = 604800;
 const STATE_TTL_SECONDS = 2592000;
 const WALL_BUDGET_MS = 13 * 60 * 1000;
 const MINIMUM_OPERATION_BUDGET_MS = 30 * 1000;
+const NOT_OPEN_DISPATCH_WINDOW_MS = 60 * 60 * 1000;
+const NOT_OPEN_OPENING_JUMP_TOLERANCE_MS = 2 * 60 * 1000;
 
 function configured(value) {
   return Boolean(String(value ?? "").trim());
@@ -66,9 +68,18 @@ function operationDescription(details) {
   const classDetails = [details.classType, "on", details.classDate, "at", details.classTime]
     .filter(Boolean)
     .join(" ");
-  return `${details.operation} ${classDetails}${
-    details.calendarEventName ? ` (${details.calendarEventName})` : ""
-  }`;
+  return `${details.operation} ${classDetails}`;
+}
+
+async function recordTrace(recorder, event) {
+  if (!recorder) {
+    return;
+  }
+  try {
+    await recorder.trace(event);
+  } catch (error) {
+    console.warn("regybox: run trace write failed:", error);
+  }
 }
 
 function parseCachedValue(value) {
@@ -115,8 +126,38 @@ async function writeState({ kv, details, result }) {
     payload.lastCheckedAt = result.lastCheckedAt;
   }
   await kv.put(details.cacheKey, JSON.stringify(payload), { expirationTtl: STATE_TTL_SECONDS });
-  console.log(`regybox: cached state=${state} for ${details.cacheKey}`);
+  console.log(`regybox: cached state=${state} for ${operationDescription(details)}`);
   return state;
+}
+
+async function assertSafeNotOpenTransition({ kv, details, result, now }) {
+  if (result.status !== "noop" || result.cacheState !== "not_open" || !result.enrollmentOpensAt) {
+    return;
+  }
+  const cached = parseCachedValue(await kv.get(details.cacheKey));
+  if (cached.state !== "not_open") {
+    return;
+  }
+  const previousOpeningMs = Date.parse(String(cached.enrollmentOpensAt ?? ""));
+  const claimedOpeningMs = Date.parse(String(result.enrollmentOpensAt));
+  if (!Number.isFinite(previousOpeningMs) || !Number.isFinite(claimedOpeningMs)) {
+    return;
+  }
+  const previousOpeningIsDueSoon = previousOpeningMs - now() <= NOT_OPEN_DISPATCH_WINDOW_MS;
+  const openingJumpMs = claimedOpeningMs - previousOpeningMs;
+  if (
+    previousOpeningIsDueSoon &&
+    openingJumpMs > NOT_OPEN_OPENING_JUMP_TOLERANCE_MS
+  ) {
+    throw new UnparseableError(
+      "Regybox moved an already-due enrollment opening unexpectedly far into the future",
+      {
+        previousEnrollmentOpensAt: new Date(previousOpeningMs).toISOString(),
+        claimedEnrollmentOpensAt: new Date(claimedOpeningMs).toISOString(),
+        openingJumpSeconds: Math.round(openingJumpMs / 1000),
+      },
+    );
+  }
 }
 
 export function executionMode(env) {
@@ -201,9 +242,13 @@ export async function executePlan({
   sleep,
   onFailure,
   onResult,
+  recorder,
 }) {
   const mode = executionMode(env);
   const statusUrl = await resolveStatusUrl(env, kv);
+  const runUrl = statusUrl && recorder?.id
+    ? `${String(statusUrl).replace(/\/+$/, "")}/runs/${recorder.id}`
+    : null;
   const reportFailure =
     onFailure ??
     (async (notification) => {
@@ -215,14 +260,15 @@ export async function executePlan({
           dispatch: notification.dispatch,
           error: notification.error,
           payload: notification.payload,
+          runId: recorder?.id,
         });
       } catch (error) {
         console.warn("regybox: incident record write failed:", error);
       }
-      return notifyFailureImpl({ env, kv, ...notification, statusUrl, incidentUrl });
+      return notifyFailureImpl({ env, kv, ...notification, statusUrl, incidentUrl, runUrl });
     });
   const reportResult =
-    onResult ?? ((notification) => notifyResultImpl({ env, kv, ...notification, statusUrl }));
+    onResult ?? ((notification) => notifyResultImpl({ env, kv, ...notification, statusUrl, runUrl }));
   const startedAt = now();
   const operations = [];
   const activity = [];
@@ -235,15 +281,35 @@ export async function executePlan({
 
   try {
     console.log(`regybox: executing ${dispatches.length} operation(s) in ${mode} mode`);
+    await recordTrace(recorder, {
+      scope: "executor",
+      code: "execution_started",
+      message: `Executing ${dispatches.length} operation(s) in ${mode} mode`,
+      data: { mode, plannedOperations: dispatches.length },
+    });
     if (mode === "dispatch") {
-      for (const dispatch of dispatches) {
+      for (const [operationIndex, dispatch] of dispatches.entries()) {
         const details = operationDetails(dispatch);
         console.log(`regybox: ${operationDescription(details)}`);
+        await recordTrace(recorder, {
+          scope: "operation",
+          operationIndex,
+          code: "dispatch_started",
+          message: `Dispatching ${operationDescription(details)} to GitHub`,
+          data: { operation: details.operation, classDate: details.classDate, classTime: details.classTime, classType: details.classType },
+        });
         try {
           await dispatchWorkflowImpl(env, dispatch);
           operations.push(summaryOperation(details, "dispatched"));
           activity.push(activityOperation(details, "dispatched", now()));
           console.log(`regybox: ${operationDescription(details)} -> dispatched to GitHub`);
+          await recordTrace(recorder, {
+            scope: "operation",
+            operationIndex,
+            code: "dispatch_succeeded",
+            message: `${operationDescription(details)} was dispatched to GitHub`,
+            data: { operation: details.operation, outcome: "dispatched" },
+          });
         } catch (error) {
           const payload = errorPayload(error);
           operations.push(summaryOperation(details, "failure", { errorCode: payload.errorCode }));
@@ -251,6 +317,14 @@ export async function executePlan({
           console.error(
             `regybox: ${operationDescription(details)} -> failure (${payload.errorCode}): ${error.message}`,
           );
+          await recordTrace(recorder, {
+            level: "error",
+            scope: "operation",
+            operationIndex,
+            code: "dispatch_failed",
+            message: `${operationDescription(details)} failed (${payload.errorCode})`,
+            data: { operation: details.operation, outcome: "failure", errorCode: payload.errorCode },
+          });
           throw error;
         }
       }
@@ -261,11 +335,30 @@ export async function executePlan({
       phpsessid: env.PHPSESSID,
       regyboxUser: env.REGYBOX_USER,
       timezone: env.TIMEZONE || "Europe/Lisbon",
+      now,
+      onTrace: (event) => recordTrace(recorder, event),
+    });
+    await recordTrace(recorder, {
+      scope: "session",
+      code: "session_bootstrap_started",
+      message: "Starting Regybox session bootstrap",
     });
     try {
       await client.bootstrapSession();
+      await recordTrace(recorder, {
+        scope: "session",
+        code: "session_bootstrap_succeeded",
+        message: "Regybox session bootstrap succeeded",
+      });
     } catch (error) {
-      for (const dispatch of dispatches) {
+      await recordTrace(recorder, {
+        level: "error",
+        scope: "session",
+        code: "session_bootstrap_failed",
+        message: "Regybox session bootstrap failed",
+        data: { errorCode: errorPayload(error).errorCode },
+      });
+      for (const [operationIndex, dispatch] of dispatches.entries()) {
         const details = operationDetails(dispatch);
         const payload = errorPayload(error);
         const fingerprint = buildFailureFingerprint({ operation: dispatch.operation, error });
@@ -274,6 +367,14 @@ export async function executePlan({
         console.error(
           `regybox: ${operationDescription(details)} -> failure (${payload.errorCode}): ${error.message}`,
         );
+        await recordTrace(recorder, {
+          level: "error",
+          scope: "operation",
+          operationIndex,
+          code: "operation_failed",
+          message: `${operationDescription(details)} failed during session bootstrap (${payload.errorCode})`,
+          data: { operation: details.operation, outcome: "failure", errorCode: payload.errorCode },
+        });
         try {
           await reportFailure({ dispatch, error, payload, fingerprint });
         } catch (notificationError) {
@@ -282,16 +383,31 @@ export async function executePlan({
       }
       throw error;
     }
-    for (const dispatch of dispatches) {
+    for (const [operationIndex, dispatch] of dispatches.entries()) {
       const details = operationDetails(dispatch);
       const remainingMs = startedAt + WALL_BUDGET_MS - now();
       if (remainingMs < MINIMUM_OPERATION_BUDGET_MS) {
         operations.push(summaryOperation(details, "skipped"));
         activity.push(activityOperation(details, "skipped", now()));
         console.log(`regybox: ${operationDescription(details)} -> skipped (out of time)`);
+        await recordTrace(recorder, {
+          level: "warn",
+          scope: "operation",
+          operationIndex,
+          code: "operation_skipped",
+          message: `${operationDescription(details)} was skipped because the invocation budget was exhausted`,
+          data: { operation: details.operation, outcome: "skipped", remainingMs },
+        });
         continue;
       }
       console.log(`regybox: ${operationDescription(details)}`);
+      await recordTrace(recorder, {
+        scope: "operation",
+        operationIndex,
+        code: "operation_started",
+        message: `Starting ${operationDescription(details)}`,
+        data: { operation: details.operation, classDate: details.classDate, classTime: details.classTime, classType: details.classType },
+      });
       let result;
       try {
         result = await runOperationImpl({
@@ -303,7 +419,13 @@ export async function executePlan({
           timeoutSeconds: Math.min(timeoutSeconds(env), Math.floor(remainingMs / 1000)),
           notOpenIsNoop: true,
           sleep,
+          onTrace: (event) => recordTrace(recorder, {
+            ...event,
+            scope: event?.scope || "regybox",
+            operationIndex,
+          }),
         });
+        await assertSafeNotOpenTransition({ kv, details, result, now });
       } catch (error) {
         const payload = errorPayload(error);
         const fingerprint = buildFailureFingerprint({ operation: details.operation, error });
@@ -312,10 +434,27 @@ export async function executePlan({
         console.error(
           `regybox: ${operationDescription(details)} -> failure (${payload.errorCode}): ${error.message}`,
         );
+        await recordTrace(recorder, {
+          level: "error",
+          scope: "operation",
+          operationIndex,
+          code: "operation_failed",
+          message: `${operationDescription(details)} failed (${payload.errorCode})`,
+          data: { operation: details.operation, outcome: "failure", errorCode: payload.errorCode },
+        });
         await reportFailure({ dispatch, error, payload, fingerprint });
         continue;
       }
       const cacheState = await writeState({ kv, details, result });
+      if (cacheState) {
+        await recordTrace(recorder, {
+          scope: "cache",
+          operationIndex,
+          code: "cache_state_written",
+          message: `Cached ${cacheState} state for ${operationDescription(details)}`,
+          data: { operation: details.operation, cacheState },
+        });
+      }
       await reportResult({ dispatch, result });
       operations.push(summaryOperation(details, result.status));
       activity.push(
@@ -331,8 +470,22 @@ export async function executePlan({
           .filter(Boolean)
           .join(", ");
         console.log(`regybox: ${operationDescription(details)} -> noop (${outcomeDetails})`);
+        await recordTrace(recorder, {
+          scope: "operation",
+          operationIndex,
+          code: "operation_noop",
+          message: `${operationDescription(details)} made no change (${outcomeDetails})`,
+          data: { operation: details.operation, outcome: "noop", cacheState: cacheState || result.cacheState },
+        });
       } else {
         console.log(`regybox: ${operationDescription(details)} -> ${result.status}`);
+        await recordTrace(recorder, {
+          scope: "operation",
+          operationIndex,
+          code: "operation_completed",
+          message: `${operationDescription(details)} completed with ${result.status}`,
+          data: { operation: details.operation, outcome: result.status, cacheState },
+        });
       }
     }
     return summary;

--- a/cloudflare/regybox-scheduler/src/incidents.js
+++ b/cloudflare/regybox-scheduler/src/incidents.js
@@ -64,7 +64,33 @@ function safeDiagnostics(error) {
     if (Array.isArray(diagnostics[key])) {
       result[key] = diagnostics[key]
         .slice(0, 10)
-        .map((item) => sanitizeText(item, 200));
+        .map((item) => {
+          try {
+            return new URL(String(item), "https://regybox.invalid").pathname;
+          } catch {
+            return "[invalid path]";
+          }
+        });
+    }
+  }
+  for (const key of [
+    "malformedBookingControls",
+    "fetchCount",
+    "graceSeconds",
+    "timerSeconds",
+    "enrollmentDeadlineExpired",
+    "openingJumpSeconds",
+  ]) {
+    if (typeof diagnostics[key] === "boolean") {
+      result[key] = diagnostics[key];
+    } else if (typeof diagnostics[key] === "number" && Number.isFinite(diagnostics[key])) {
+      result[key] = diagnostics[key];
+    }
+  }
+  for (const key of ["previousEnrollmentOpensAt", "claimedEnrollmentOpensAt"]) {
+    const timestamp = Date.parse(String(diagnostics[key] ?? ""));
+    if (Number.isFinite(timestamp)) {
+      result[key] = new Date(timestamp).toISOString();
     }
   }
   return Object.keys(result).length > 0 ? result : undefined;
@@ -111,7 +137,7 @@ export async function resolveStatusUrl(env, kv) {
   }
 }
 
-export async function recordIncident({ kv, dispatch, error, payload, statusUrl, now = () => Date.now() }) {
+export async function recordIncident({ kv, dispatch, error, payload, statusUrl, runId, now = () => Date.now() }) {
   if (!kv) {
     return null;
   }
@@ -131,6 +157,9 @@ export async function recordIncident({ kv, dispatch, error, payload, statusUrl, 
     errorName: sanitizeText(error?.name ?? "Error", 100),
     technicalMessage: sanitizeText(payload?.technicalMessage ?? error?.message),
   };
+  if (/^[a-f0-9]{36}$/.test(String(runId ?? ""))) {
+    record.runId = runId;
+  }
   const parserDiagnostics = safeDiagnostics(error);
   if (parserDiagnostics) {
     record.parserDiagnostics = parserDiagnostics;

--- a/cloudflare/regybox-scheduler/src/index.js
+++ b/cloudflare/regybox-scheduler/src/index.js
@@ -8,7 +8,8 @@ import {
 } from "./calendar.js";
 import { appendActivity, dispatchWorkflow, executePlan, executionMode, writeLastRun } from "./executor.js";
 import { rememberStatusOrigin } from "./incidents.js";
-import { handleIncidentRequest, handleStatusRequest } from "./status.js";
+import { createRunRecorder, outcomeStatus } from "./runs.js";
+import { handleIncidentRequest, handleRunRequest, handleRunsRequest, handleStatusRequest } from "./status.js";
 
 export {
   buildPlan,
@@ -20,10 +21,40 @@ export {
   dispatchWorkflow,
 };
 
-export async function handleScheduled(env) {
+async function safeRecorderCall(recorder, method, ...args) {
+  if (!recorder) return null;
+  try {
+    return await recorder[method](...args);
+  } catch (error) {
+    console.warn(`regybox: run ${method} write failed:`, error);
+    return null;
+  }
+}
+
+function resolvedMode(env) {
+  try {
+    return executionMode(env);
+  } catch {
+    return "unconfigured";
+  }
+}
+
+export async function handleScheduled(env, { scheduledAt, now = () => Date.now() } = {}) {
+  const mode = resolvedMode(env);
+  let recorder = null;
+  try {
+    recorder = await createRunRecorder({ kv: env.REGYBOX_STATE, mode, scheduledAt, now });
+  } catch (error) {
+    console.warn("regybox: run recorder start failed:", error);
+  }
   let plan;
   try {
     console.log("regybox: calendar fetch started");
+    await safeRecorderCall(recorder, "trace", {
+      scope: "calendar",
+      code: "calendar_fetch_started",
+      message: "Calendar fetch started",
+    });
     const calendarResponse = await fetch(env.CALENDAR_URL);
     if (!calendarResponse.ok) {
       throw new Error(`Calendar fetch failed: ${calendarResponse.status}`);
@@ -32,57 +63,112 @@ export async function handleScheduled(env) {
       env,
       kv: env.REGYBOX_STATE,
       icsText: await calendarResponse.text(),
+      now: new Date(now()),
+      onTrace: (event) => safeRecorderCall(recorder, "trace", event),
     });
     console.log(`regybox: calendar fetched, ${plan.events.length} events in window`);
     console.log(`regybox: plan built, ${plan.dispatches.length} operation(s)`);
+    await safeRecorderCall(recorder, "trace", {
+      scope: "calendar",
+      code: "plan_built",
+      message: `Calendar fetched; ${plan.events.length} relevant event(s) and ${plan.dispatches.length} operation(s) planned`,
+      data: { eventCount: plan.events.length, plannedOperations: plan.dispatches.length },
+    });
+    await safeRecorderCall(recorder, "setPlan", plan.dispatches.length);
   } catch (error) {
     console.error(`regybox: calendar/plan failed: ${error.message}`);
-    const mode = (() => {
-      try {
-        return executionMode(env);
-      } catch {
-        return "unconfigured";
-      }
-    })();
+    await safeRecorderCall(recorder, "trace", {
+      level: "error",
+      scope: "calendar",
+      code: "calendar_or_plan_failed",
+      message: "Calendar fetch or plan construction failed",
+      data: { errorCode: "calendar_or_plan_failure" },
+    });
+    const operations = [{ operation: "calendar", outcome: "failure", errorCode: "calendar_or_plan_failure" }];
     try {
       await writeLastRun(env.REGYBOX_STATE, {
-        ranAt: new Date().toISOString(),
+        ranAt: new Date(now()).toISOString(),
         mode,
         plannedOperations: 0,
-        operations: [{ operation: "calendar", outcome: "failure", errorCode: "calendar_or_plan_failure" }],
+        operations,
       });
     } catch {
       // Preserve the calendar/build failure as the scheduled-handler error.
     }
     await appendActivity(env.REGYBOX_STATE, [
       {
-        at: new Date().toISOString(),
+        at: new Date(now()).toISOString(),
         operation: "calendar",
         outcome: "failure",
         errorCode: "calendar_or_plan_failure",
       },
     ]);
+    await safeRecorderCall(recorder, "finalize", {
+      status: "failure",
+      operations,
+      errorCode: "calendar_or_plan_failure",
+    });
     throw error;
   }
-  await executePlan({ env, kv: env.REGYBOX_STATE, dispatches: plan.dispatches });
+  let summary;
+  try {
+    summary = await executePlan({ env, kv: env.REGYBOX_STATE, dispatches: plan.dispatches, now, recorder });
+  } catch (error) {
+    const operations = [];
+    await safeRecorderCall(recorder, "trace", {
+      level: "error",
+      scope: "executor",
+      code: "execution_failed",
+      message: "Run execution failed",
+      data: { errorCode: "execution_failure" },
+    });
+    await safeRecorderCall(recorder, "finalize", {
+      status: "failure",
+      operations,
+      errorCode: "execution_failure",
+    });
+    throw error;
+  }
+  await safeRecorderCall(recorder, "trace", {
+    scope: "run",
+    code: "run_completed",
+    message: `Run completed with ${outcomeStatus(summary.operations)}`,
+    data: { outcome: outcomeStatus(summary.operations), plannedOperations: summary.plannedOperations },
+  });
+  await safeRecorderCall(recorder, "finalize", {
+    status: outcomeStatus(summary.operations),
+    operations: summary.operations,
+  });
   return plan.dispatches.length;
 }
 
 export default {
-  async scheduled(_event, env, _ctx) {
-    await handleScheduled(env);
+  async scheduled(event, env, _ctx) {
+    await handleScheduled(env, { scheduledAt: event?.scheduledTime });
   },
   async fetch(request, env, _ctx) {
     const url = new URL(request.url);
     const incidentMatch = url.pathname.match(/\/incidents\/([a-f0-9]{36})\/?$/);
     if (incidentMatch) {
-      return handleIncidentRequest(env.REGYBOX_STATE, incidentMatch[1]);
+      const basePath = url.pathname.slice(0, incidentMatch.index).replace(/\/+$/, "");
+      return handleIncidentRequest(env.REGYBOX_STATE, incidentMatch[1], { basePath });
+    }
+    const runMatch = url.pathname.match(/\/runs\/([a-f0-9]{36})\/?$/);
+    if (runMatch) {
+      const basePath = url.pathname.slice(0, runMatch.index).replace(/\/+$/, "");
+      return handleRunRequest(env.REGYBOX_STATE, runMatch[1], { basePath });
+    }
+    const runsMatch = url.pathname.match(/\/runs\/?$/);
+    if (runsMatch) {
+      const basePath = url.pathname.slice(0, runsMatch.index).replace(/\/+$/, "");
+      return handleRunsRequest(env.REGYBOX_STATE, { basePath });
     }
     try {
-      await rememberStatusOrigin(env.REGYBOX_STATE, url.origin);
+      await rememberStatusOrigin(env.REGYBOX_STATE, url.href);
     } catch (error) {
       console.warn("regybox: status origin write failed:", error);
     }
-    return handleStatusRequest(env, env.REGYBOX_STATE);
+    const basePath = url.pathname.replace(/\/+$/, "");
+    return handleStatusRequest(env, env.REGYBOX_STATE, { basePath });
   },
 };

--- a/cloudflare/regybox-scheduler/src/notify.js
+++ b/cloudflare/regybox-scheduler/src/notify.js
@@ -54,7 +54,15 @@ export function classSummary({ classType, classDate, classTime }) {
 }
 
 /** Build the plain-text email content for a completed worker operation. */
-export function composeEmail({ kind, operation, classSummary: summary, payload = {}, statusUrl, incidentUrl }) {
+export function composeEmail({
+  kind,
+  operation,
+  classSummary: summary,
+  payload = {},
+  statusUrl,
+  incidentUrl,
+  runUrl,
+}) {
   const operationName = operationLabel(operation);
   const operationNoun = operationName === "unenroll" ? "unenrollment" : "enrollment";
 
@@ -68,6 +76,9 @@ export function composeEmail({ kind, operation, classSummary: summary, payload =
     ];
     if (statusUrl) {
       bodyLines.push("", `Status page: ${statusUrl}`);
+    }
+    if (runUrl) {
+      bodyLines.push("", `Run details: ${runUrl}`);
     }
     return {
       subject: `Regybox Auto-${operationName}: success for ${summary}`,
@@ -97,6 +108,9 @@ export function composeEmail({ kind, operation, classSummary: summary, payload =
       "",
       `More details (available for ${incidentConstants.INCIDENT_RETENTION_DAYS} days): ${incidentUrl}`,
     );
+  }
+  if (runUrl) {
+    bodyLines.push("", `Run timeline: ${runUrl}`);
   }
   if (statusUrl) {
     bodyLines.push("", `Status page: ${statusUrl}`);
@@ -143,7 +157,7 @@ export async function sendEmail(env, { subject, body }, { mailerFactory } = {}) 
 }
 
 /** Notify successful worker results; noops are intentionally silent. */
-export async function notifyResult({ env, kv, dispatch, result, statusUrl, send = sendEmail }) {
+export async function notifyResult({ env, kv, dispatch, result, statusUrl, runUrl, send = sendEmail }) {
   if (!emailConfigured(env) || result.status !== "success") {
     return;
   }
@@ -159,6 +173,7 @@ export async function notifyResult({ env, kv, dispatch, result, statusUrl, send 
           classTime: dispatch.inputs?.["class-time"],
         }),
         statusUrl,
+        runUrl,
       }),
     );
     console.log(`regybox: email sent (${dispatch.operation} success)`);
@@ -177,6 +192,7 @@ export async function notifyFailure({
   fingerprint,
   statusUrl,
   incidentUrl,
+  runUrl,
   send = sendEmail,
 }) {
   if (!emailConfigured(env)) {
@@ -210,6 +226,7 @@ export async function notifyFailure({
         payload,
         statusUrl,
         incidentUrl,
+        runUrl,
       }),
     );
   } catch (notificationError) {

--- a/cloudflare/regybox-scheduler/src/regybox.js
+++ b/cloudflare/regybox-scheduler/src/regybox.js
@@ -1,13 +1,12 @@
+import { parseFragment } from "parse5";
+
 const DOMAIN = "https://www.regybox.pt/app/app_nova/";
 const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
-const DIV_TAG_RE = /<\/?div\b[^>]*>/gi;
-const TAG_RE = /<[^>]+>/g;
 const SCRIPT_RE = /<script\b[^>]*>([\s\S]*?)<\/script\s*>/gi;
-const ATTR_RE = /([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
-const BUTTON_RE = /<button\b([^>]*)>/gi;
-const INPUT_RE = /<input\b([^>]*)>/gi;
 const DOMAIN_ORIGIN = new URL(DOMAIN).origin;
 const CLASS_ACTION_PATH_PREFIX = "/app/app_nova/php/aulas/";
+const OPENING_ROLLOVER_GRACE_MS = 30_000;
+const OPENING_ROLLOVER_TOLERANCE_SECONDS = 60;
 
 export class RegyboxLoginError extends Error {
   constructor(message = "Unable to log in") {
@@ -72,24 +71,35 @@ export class NoClassesFoundError extends Error {
   }
 }
 
-function parseAttributes(raw) {
-  const attrs = {};
-  for (const match of raw.matchAll(ATTR_RE)) {
-    const [, name, doubleQuoted, singleQuoted, bare] = match;
-    if (name) {
-      attrs[name.toLowerCase()] = decodeEntities(doubleQuoted ?? singleQuoted ?? bare ?? "");
-    }
-  }
-  return attrs;
+function attributes(node) {
+  return Object.fromEntries((node?.attrs ?? []).map(({ name, value }) => [name.toLowerCase(), value]));
 }
 
-function classTokens(attrs) {
-  return String(attrs.class ?? "").split(/\s+/).filter(Boolean);
+function classTokens(node) {
+  return String(attributes(node).class ?? "").split(/\s+/).filter(Boolean);
 }
 
-function hasClass(attrs, ...names) {
-  const tokens = new Set(classTokens(attrs));
+function hasClass(node, ...names) {
+  const tokens = new Set(classTokens(node));
   return names.every((name) => tokens.has(name));
+}
+
+function elements(root, tagName = null) {
+  const matches = [];
+  const visit = (node) => {
+    if (node?.tagName && (!tagName || node.tagName === tagName)) {
+      matches.push(node);
+    }
+    for (const child of node?.childNodes ?? []) {
+      visit(child);
+    }
+  };
+  visit(root);
+  return matches;
+}
+
+function descendants(root, tagName = null) {
+  return elements({ childNodes: root?.childNodes ?? [] }, tagName);
 }
 
 function decodeEntities(value) {
@@ -125,60 +135,54 @@ function fixText(value) {
   }
 }
 
-function textContent(html) {
-  return fixText(decodeEntities(String(html).replace(TAG_RE, " ")));
-}
-
-function divNodes(html) {
-  const nodes = [];
-  const stack = [];
-  for (const match of html.matchAll(DIV_TAG_RE)) {
-    const tag = match[0];
-    if (tag.startsWith("</")) {
-      const node = stack.pop();
-      if (node) {
-        node.inner = html.slice(node.openEnd, match.index);
-        node.end = match.index + tag.length;
-        nodes.push(node);
-      }
-    } else {
-      const attrs = parseAttributes(tag.slice(4, -1));
-      stack.push({ attrs, start: match.index, openEnd: match.index + tag.length, inner: "", end: null });
+function textContent(node) {
+  const parts = [];
+  const visit = (current) => {
+    if (current?.nodeName === "#text") {
+      parts.push(current.value);
     }
-  }
-  return nodes.sort((left, right) => left.start - right.start);
+    for (const child of current?.childNodes ?? []) {
+      visit(child);
+    }
+  };
+  visit(node);
+  return fixText(parts.join(" "));
 }
 
-function classBlocks(html) {
-  return divNodes(html)
-    .filter((node) => hasClass(node.attrs, "filtro0"))
-    .map((node) => html.slice(node.start, node.end));
+function parseClassDocument(html) {
+  return parseFragment(String(html));
+}
+
+function classBlocks(document) {
+  return elements(document, "div").filter((node) => hasClass(node, "filtro0"));
 }
 
 function findDiv(nodes, predicate) {
-  return nodes.find((node) => predicate(node.attrs, node.inner));
+  return nodes.find((node) => predicate(attributes(node), node));
 }
 
 function findLastDiv(nodes, predicate) {
   for (let index = nodes.length - 1; index >= 0; index -= 1) {
-    if (predicate(nodes[index].attrs, nodes[index].inner)) {
+    if (predicate(attributes(nodes[index]), nodes[index])) {
       return nodes[index];
     }
   }
   return undefined;
 }
 
-function hasStyle(attrs, pattern) {
-  return pattern.test(String(attrs.style ?? ""));
+function hasStyle(node, pattern) {
+  return pattern.test(String(attributes(node).style ?? ""));
 }
 
 function buttonActions(block) {
   const actions = [];
   const unknownActionEndpoints = [];
-  for (const match of block.matchAll(BUTTON_RE)) {
-    const attrs = parseAttributes(match[1]);
-    const looksLikeBookingControl = hasClass(attrs, "buts_inscrever");
+  let malformedBookingControls = 0;
+  for (const button of descendants(block, "button")) {
+    const attrs = attributes(button);
+    const looksLikeBookingControl = hasClass(button, "buts_inscrever");
     const urls = String(attrs.onclick ?? "").match(/[^'"\s,(]+\.php(?:\?[^'"\s,)]*)?/gi) ?? [];
+    let recognizedForButton = false;
     for (const rawUrl of urls) {
       let url;
       try {
@@ -200,16 +204,22 @@ function buttonActions(block) {
       }
       if (pathname === `${CLASS_ACTION_PATH_PREFIX}marca_aulas.php`) {
         actions.push({ operation: "enroll", url: url.href, pathname });
+        recognizedForButton = true;
       } else if (pathname === `${CLASS_ACTION_PATH_PREFIX}cancela_aula.php`) {
         actions.push({ operation: "unenroll", url: url.href, pathname });
+        recognizedForButton = true;
       } else if (looksLikeBookingControl && /\/aulas\/[^/]+\.php$/i.test(pathname)) {
         unknownActionEndpoints.push(pathname);
       }
+    }
+    if (looksLikeBookingControl && !recognizedForButton && unknownActionEndpoints.length === 0) {
+      malformedBookingControls += 1;
     }
   }
   const diagnostics = {
     actionEndpoints: actions.map(({ pathname }) => pathname),
     unknownActionEndpoints,
+    malformedBookingControls,
   };
   if (unknownActionEndpoints.length > 0) {
     throw new UnparseableError(
@@ -223,13 +233,16 @@ function buttonActions(block) {
       diagnostics,
     );
   }
+  if (malformedBookingControls > 0) {
+    throw new UnparseableError("Booking control did not contain a recognizable class action", diagnostics);
+  }
   return actions[0] ?? null;
 }
 
 function timerValue(block) {
-  for (const match of block.matchAll(INPUT_RE)) {
-    const attrs = parseAttributes(match[1]);
-    if (hasClass(attrs, "timers")) {
+  for (const input of descendants(block, "input")) {
+    const attrs = attributes(input);
+    if (hasClass(input, "timers")) {
       const value = Number.parseInt(attrs.value, 10);
       if (!Number.isFinite(value)) {
         throw new UnparseableError(`Unexpected timer value: ${attrs.value}`);
@@ -254,39 +267,38 @@ function zonedDate(epochSeconds, timezone) {
 }
 
 function parseClassBlock(block, { timezone }) {
-  const rootMatch = block.match(/^<div\b([^>]*)>/i);
-  const rootAttrs = rootMatch ? parseAttributes(rootMatch[1]) : null;
+  const rootAttrs = attributes(block);
   const timestamp = String(rootAttrs?.id ?? "").match(/^feed_time_slot(\d+)$/);
   if (!timestamp) {
     throw new UnparseableError("Missing class timestamp");
   }
-  const nodes = divNodes(block);
+  const nodes = descendants(block, "div");
   const leftHalf = nodes.filter(
-    (node) => node.attrs.align === "left" && hasClass(node.attrs, "col-50"),
+    (node) => attributes(node).align === "left" && hasClass(node, "col-50"),
   );
   if (leftHalf.length === 0) {
     throw new UnparseableError("Missing class name");
   }
   const rightHalf = nodes.find(
-    (node) => node.attrs.align === "right" && hasClass(node.attrs, "col-50"),
+    (node) => attributes(node).align === "right" && hasClass(node, "col-50"),
   );
   const timeNode = findDiv(
     nodes,
-    (attrs, inner) =>
+    (attrs, node) =>
       attrs.align === "left" &&
-      hasClass(attrs, "col") &&
-      /\b\d{1,2}:\d{2}\s*-\s*\d{1,2}:\d{2}\b/.test(textContent(inner)),
+      hasClass(node, "col") &&
+      /\b\d{1,2}:\d{2}\s*-\s*\d{1,2}:\d{2}\b/.test(textContent(node)),
   );
   const capacityNode = findDiv(
     nodes,
-    (attrs, inner) =>
-      attrs.align === "center" && hasClass(attrs, "col") && /\S+\s+(?:of|de)\s+\S+/i.test(textContent(inner)),
+    (attrs, node) =>
+      attrs.align === "center" && hasClass(node, "col") && /\S+\s+(?:of|de)\s+\S+/i.test(textContent(node)),
   );
   if (!rightHalf || !timeNode || !capacityNode) {
     throw new UnparseableError("Missing class fields");
   }
-  const time = textContent(timeNode.inner).match(/^(\d{1,2}:\d{2})\s*-\s*(\d{1,2}:\d{2})$/);
-  const capacity = textContent(capacityNode.inner).match(/^(\S+)\s+(?:of|de)\s+(\S+)$/i);
+  const time = textContent(timeNode).match(/^(\d{1,2}:\d{2})\s*-\s*(\d{1,2}:\d{2})$/);
+  const capacity = textContent(capacityNode).match(/^(\S+)\s+(?:of|de)\s+(\S+)$/i);
   if (!time || !capacity) {
     throw new UnparseableError("Unexpected time or capacity format");
   }
@@ -297,14 +309,14 @@ function parseClassBlock(block, { timezone }) {
   const maxCapacity = parseCapacity(capacity[2]);
   const buttonAction = buttonActions(block);
   const isOpenByOtherEnrollment = nodes.some(
-    (node) => hasClass(node.attrs, "letra_10") && hasStyle(node.attrs, /padding-top:\s*7px/i),
+    (node) => hasClass(node, "letra_10") && hasStyle(node, /padding-top:\s*7px/i),
   );
   const isOpen = Boolean(buttonAction) || isOpenByOtherEnrollment;
   const enrolledStatus = nodes.some(
     (node) =>
-      node.attrs.align === "right" &&
-      hasClass(node.attrs, "ok_color") &&
-      hasStyle(node.attrs, /padding-top:\s*1px/i),
+      attributes(node).align === "right" &&
+      hasClass(node, "ok_color") &&
+      hasStyle(node, /padding-top:\s*1px/i),
   );
   let userIsEnrolled = enrolledStatus;
   let enrollUrl = null;
@@ -315,8 +327,8 @@ function parseClassBlock(block, { timezone }) {
   } else if (!enrolledStatus && buttonAction?.operation === "enroll") {
     enrollUrl = buttonAction.url;
   }
-  const error = /<span\b[^>]*\bclass\s*=\s*(["'])[^"']*\berro_color\b[^"']*\1/i.test(block);
-  const userIsWaitlisted = nodes.some((node) => hasClass(node.attrs, "preloader", "color-orange"));
+  const error = descendants(block, "span").some((node) => hasClass(node, "erro_color"));
+  const userIsWaitlisted = nodes.some((node) => hasClass(node, "preloader", "color-orange"));
   const isFull = maxCapacity === null ? false : curCapacity >= maxCapacity;
   const isOverbooked = isFull && error;
   const enrollmentDeadlineExpired = error && !isFull;
@@ -324,32 +336,32 @@ function parseClassBlock(block, { timezone }) {
   let isOver = false;
   const state = findLastDiv(
     nodes,
-    (attrs) => attrs.align === "right" && hasClass(attrs, "col"),
+    (attrs, node) => attrs.align === "right" && hasClass(node, "col"),
   );
   if (!state) {
     throw new UnparseableError("Missing class state");
   }
-  if (/<span\b[^>]*\bclass\s*=\s*(["'])[^"']*\berro_color\b[^"']*\1/i.test(state.inner)) {
+  if (descendants(state, "span").some((node) => hasClass(node, "erro_color"))) {
     userIsBlocked = true;
   } else {
     const stateChild = findDiv(
-      divNodes(state.inner),
-      (attrs) => hasStyle(attrs, /padding-top:\s*7px/i),
+      descendants(state, "div"),
+      (_attrs, node) => hasStyle(node, /padding-top:\s*7px/i),
     );
     if (stateChild) {
       if (userIsWaitlisted) {
         isOver = false;
-      } else if (!stateChild.attrs.class) {
+      } else if (!attributes(stateChild).class) {
         isOver = true;
-      } else if (hasClass(stateChild.attrs, "letra_10")) {
+      } else if (hasClass(stateChild, "letra_10")) {
         userIsBlocked = true;
       }
     }
   }
   const timer = timerValue(block);
   return {
-    name: textContent(leftHalf[0].inner),
-    details: textContent(rightHalf.inner),
+    name: textContent(leftHalf[0]),
+    details: textContent(rightHalf),
     date: zonedDate(Number.parseInt(timestamp[1], 10), timezone),
     start: time[1],
     end: time[2],
@@ -383,7 +395,7 @@ export function parseCapacity(value) {
 
 export function parseClasses(html, { date, timezone = "Europe/Lisbon" } = {}) {
   void date; // The timestamp embedded in each card is the Python source of truth.
-  return classBlocks(String(html)).map((block) => parseClassBlock(block, { timezone }));
+  return classBlocks(parseClassDocument(html)).map((block) => parseClassBlock(block, { timezone }));
 }
 
 function parseClassesAtTime(
@@ -391,7 +403,7 @@ function parseClassesAtTime(
   { classTime, classTypes = [], date, timezone = "Europe/Lisbon" } = {},
 ) {
   void date; // The timestamp embedded in each card is the Python source of truth.
-  const blocks = classBlocks(String(html));
+  const blocks = classBlocks(parseClassDocument(html));
   return {
     total: blocks.length,
     classes: blocks
@@ -411,21 +423,29 @@ function hasCandidateClassName(block, classTypes) {
   if (candidates.size === 0) {
     return true;
   }
-  const nameNode = divNodes(block).find(
-    (node) => node.attrs.align === "left" && hasClass(node.attrs, "col-50"),
+  const nameNode = descendants(block, "div").find(
+    (node) => attributes(node).align === "left" && hasClass(node, "col-50"),
   );
-  return Boolean(nameNode && candidates.has(textContent(nameNode.inner).toUpperCase()));
+  return Boolean(nameNode && candidates.has(textContent(nameNode).toUpperCase()));
 }
 
 function hasClassTime(block, classTime) {
-  const [hour, minute] = String(classTime).split(":");
-  const escapedHour = hour.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const escapedMinute = String(minute ?? "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return block.includes(classTime) || new RegExp(`${escapedHour}&#(?:0*58|x0*3a);${escapedMinute}`, "i").test(block);
+  const time = String(classTime);
+  return descendants(block, "div").some(
+    (node) =>
+      attributes(node).align === "left" &&
+      hasClass(node, "col") &&
+      textContent(node).startsWith(`${time} -`),
+  );
 }
 
 export function parseClass(html, { timezone = "Europe/Lisbon" } = {}) {
-  return parseClassBlock(String(html), { timezone });
+  const document = parseClassDocument(html);
+  const block = classBlocks(document)[0] ?? elements(document, "div")[0];
+  if (!block) {
+    throw new UnparseableError("Missing class card");
+  }
+  return parseClassBlock(block, { timezone });
 }
 
 export function pickClass(classes, { classTime, classType, classDate }) {
@@ -499,6 +519,8 @@ export function createRegyboxClient({
   retryTotal = 4,
   retryBackoffMs = 50,
   sleep = defaultSleep,
+  now = () => Date.now(),
+  onTrace = async () => {},
 } = {}) {
   if (!phpsessid || !regyboxUser) {
     throw new Error("phpsessid and regyboxUser are required");
@@ -512,6 +534,13 @@ export function createRegyboxClient({
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
     "X-Requested-With": "XMLHttpRequest",
   };
+  const emitTrace = async (event) => {
+    try {
+      await onTrace(event);
+    } catch (error) {
+      console.warn("regybox: HTTP trace callback failed:", error);
+    }
+  };
 
   async function getHtml(path, params = {}) {
     const url = new URL(path, DOMAIN);
@@ -520,18 +549,57 @@ export function createRegyboxClient({
     }
     let response;
     for (let attempt = 0; attempt <= retryTotal; attempt += 1) {
+      const requestStartedAt = now();
       try {
         response = await fetchImpl(url.href, { headers, method: "GET" });
       } catch (error) {
+        await emitTrace({
+          level: attempt === retryTotal ? "error" : "warn",
+          scope: "http",
+          code: "regybox_request_network_error",
+          message: attempt === retryTotal
+            ? `Regybox request failed after ${attempt + 1} attempt(s)`
+            : `Regybox request failed; retrying attempt ${attempt + 2}`,
+          data: {
+            attempt: attempt + 1,
+            durationMs: Math.max(0, now() - requestStartedAt),
+            endpointPath: url.pathname,
+            nextRetryMs: attempt === retryTotal ? undefined : retryBackoffMs * 2 ** attempt,
+          },
+        });
         if (attempt === retryTotal) {
           throw error;
         }
         await sleep(retryBackoffMs * 2 ** attempt);
         continue;
       }
+      await emitTrace({
+        level: RETRYABLE_STATUS_CODES.has(response.status) ? "warn" : "info",
+        scope: "http",
+        code: "regybox_response_received",
+        message: `Regybox request returned HTTP ${response.status}`,
+        data: {
+          attempt: attempt + 1,
+          durationMs: Math.max(0, now() - requestStartedAt),
+          endpointPath: url.pathname,
+          httpStatus: response.status,
+        },
+      });
       if (!RETRYABLE_STATUS_CODES.has(response.status) || attempt === retryTotal) {
         break;
       }
+      await emitTrace({
+        level: "warn",
+        scope: "http",
+        code: "regybox_request_retry",
+        message: `Regybox returned HTTP ${response.status}; retrying attempt ${attempt + 2}`,
+        data: {
+          attempt: attempt + 1,
+          endpointPath: url.pathname,
+          httpStatus: response.status,
+          nextRetryMs: retryBackoffMs * 2 ** attempt,
+        },
+      });
       await sleep(retryBackoffMs * 2 ** attempt);
     }
     if (!response?.ok) {
@@ -650,11 +718,13 @@ async function loadClasses(
     sleep = defaultSleep,
     emptyRetryTotal = 3,
     emptyRetryBackoffMs = 50,
+    beforeFetch = async () => {},
   },
 ) {
   // Python's _get_classes_tags_with_retry treats an empty class list as
   // transient; a bounded retry keeps that behavior within the subrequest cap.
   for (let attempt = 0; ; attempt += 1) {
+    await beforeFetch();
     const html = await client.fetchClassesHtml(zonedMidnightMs(classDate, timezone));
     const { total, classes } = parseClassesAtTime(html, {
       classTime,
@@ -682,7 +752,8 @@ export async function runOperation({
   notOpenIsNoop = false,
   now = () => Date.now(),
   sleep = defaultSleep,
-  maxPolls = 20,
+  maxPolls = 40,
+  onTrace = async () => {},
 } = {}) {
   if (!client || !classDate || !classTime) {
     throw new Error("client, classDate, and classTime are required");
@@ -696,9 +767,30 @@ export async function runOperation({
     throw new Error("classType must include at least one class name");
   }
   const timezone = client.timezone ?? "Europe/Lisbon";
+  const emitTrace = async (event) => {
+    try {
+      await onTrace(event);
+    } catch (error) {
+      console.warn("regybox: operation trace callback failed:", error);
+    }
+  };
+  let fetches = 0;
+  const beforeFetch = async () => {
+    if (fetches >= maxPolls) {
+      await emitTrace({
+        level: "error",
+        scope: "regybox",
+        code: "class_fetch_limit_reached",
+        message: `Stopped after ${maxPolls} class-page fetches`,
+        data: { fetchCount: fetches, fetchLimit: maxPolls },
+      });
+      throw new RegyboxTimeoutError(timeoutSeconds);
+    }
+    fetches += 1;
+  };
   if (operation === "unenroll") {
     const classes = await loadClasses(client, {
-      classDate, classTime: normalizedClassTime, classTypes, timezone, sleep,
+      classDate, classTime: normalizedClassTime, classTypes, timezone, sleep, beforeFetch,
     });
     let firstMatch = null;
     for (const candidate of classTypes) {
@@ -713,7 +805,19 @@ export async function runOperation({
           if (!selected.unenrollUrl) {
             throw new UnparseableError("Unenroll URL is not set");
           }
+          await emitTrace({
+            level: "info",
+            scope: "regybox",
+            code: "unenrollment_attempt",
+            message: "Attempting to cancel enrollment",
+          });
           await client.unenroll(selected.unenrollUrl);
+          await emitTrace({
+            level: "info",
+            scope: "regybox",
+            code: "unenrollment_success",
+            message: "Enrollment cancelled successfully",
+          });
           return operationResult("unenroll", "success", selected.name);
         }
       } catch (error) {
@@ -726,21 +830,43 @@ export async function runOperation({
   }
 
   const startedAt = now();
-  let polls = 0;
-  let lastSelected = null;
-  while (polls < maxPolls && now() - startedAt < timeoutSeconds * 1000) {
-    polls += 1;
+  let predictedOpeningAt = null;
+  let openingBecameImminent = false;
+  let rolloverGraceStartedAt = null;
+  let hasWaited = false;
+  let previousTimerSeconds = null;
+  while (now() - startedAt < timeoutSeconds * 1000) {
     const classes = await loadClasses(client, {
-      classDate, classTime: normalizedClassTime, classTypes, timezone, sleep,
+      classDate, classTime: normalizedClassTime, classTypes, timezone, sleep, beforeFetch,
     });
     const selected = pickFirstClass(classes, {
       classTime: normalizedClassTime,
       classTypes,
       classDate,
     });
-    lastSelected = selected;
     const resolvedClassType = selected.name || classTypes[0];
+    const observedAt = now();
+    await emitTrace({
+      level: "info",
+      scope: "regybox",
+      code: "class_state_observed",
+      message: "Parsed class state",
+      data: {
+        fetchCount: fetches,
+        isOpen: selected.isOpen,
+        userIsEnrolled: selected.userIsEnrolled,
+        isFull: selected.isFull,
+        enrollmentDeadlineExpired: selected.enrollmentDeadlineExpired,
+        timerSeconds: selected.timeToEnroll,
+      },
+    });
     if (selected.userIsEnrolled) {
+      await emitTrace({
+        level: "info",
+        scope: "regybox",
+        code: "already_enrolled",
+        message: "Skipped because the user is already enrolled",
+      });
       return operationResult("enroll", "noop", resolvedClassType);
     }
     if (selected.isOverbooked && selected.isFull) {
@@ -750,42 +876,132 @@ export async function runOperation({
       if (!selected.enrollUrl) {
         throw new ClassNotOpenError("Class is open but cannot be enrolled");
       }
+      await emitTrace({
+        level: "info",
+        scope: "regybox",
+        code: "enrollment_attempt",
+        message: "Attempting to enroll",
+      });
       try {
         await client.enroll(selected.enrollUrl);
       } catch (error) {
         if (error instanceof UserAlreadyEnrolledError) {
+          await emitTrace({
+            level: "info",
+            scope: "regybox",
+            code: "already_enrolled",
+            message: "Enrollment response reported that the user is already enrolled",
+          });
           return operationResult("enroll", "noop", resolvedClassType);
         }
         throw error;
       }
+      await emitTrace({
+        level: "info",
+        scope: "regybox",
+        code: "enrollment_success",
+        message: "Enrolled successfully",
+      });
       return operationResult("enroll", "success", resolvedClassType);
     }
     const timeToEnroll = selected.timeToEnroll;
-    const elapsedSeconds = Math.max(0, Math.ceil((now() - startedAt) / 1000));
+    const hasTimer = timeToEnroll !== null && timeToEnroll !== undefined;
+    const observedOpeningAt = hasTimer ? observedAt + timeToEnroll * 1000 : null;
+    predictedOpeningAt ??= observedOpeningAt;
+    if (hasTimer && timeToEnroll <= 10) {
+      openingBecameImminent = true;
+    }
+    const timerJumped = Boolean(
+      openingBecameImminent &&
+      observedOpeningAt !== null &&
+      predictedOpeningAt !== null &&
+      observedOpeningAt - predictedOpeningAt > OPENING_ROLLOVER_TOLERANCE_SECONDS * 1000,
+    );
+    const openingStateDisappeared = Boolean(
+      openingBecameImminent && (selected.enrollmentDeadlineExpired || !hasTimer),
+    );
+    if ((timerJumped || openingStateDisappeared) && rolloverGraceStartedAt === null) {
+      rolloverGraceStartedAt = observedAt;
+      const message = timerJumped
+        ? `Timer jumped from ${previousTimerSeconds} seconds to ${timeToEnroll} seconds; treating as an opening-boundary inconsistency`
+        : "Opening countdown disappeared at the enrollment boundary; treating as an opening-boundary inconsistency";
+      await emitTrace({
+        level: "error",
+        scope: "regybox",
+        code: "opening_boundary_inconsistency",
+        message,
+        data: {
+          previousTimerSeconds,
+          timerSeconds: timeToEnroll,
+          enrollmentDeadlineExpired: selected.enrollmentDeadlineExpired,
+        },
+      });
+    }
+    if (rolloverGraceStartedAt !== null) {
+      const graceElapsedMs = observedAt - rolloverGraceStartedAt;
+      if (graceElapsedMs >= OPENING_ROLLOVER_GRACE_MS) {
+        throw new UnparseableError("Enrollment state remained inconsistent after opening", {
+          fetchCount: fetches,
+          graceSeconds: OPENING_ROLLOVER_GRACE_MS / 1000,
+          timerSeconds: timeToEnroll,
+          enrollmentDeadlineExpired: selected.enrollmentDeadlineExpired,
+        });
+      }
+      hasWaited = true;
+      await emitTrace({
+        level: "warn",
+        scope: "regybox",
+        code: "opening_boundary_grace_retry",
+        message: "Opening-boundary state is inconsistent; retrying in 1 second",
+        data: {
+          waitSeconds: 1,
+          graceRemainingSeconds: Math.ceil((OPENING_ROLLOVER_GRACE_MS - graceElapsedMs) / 1000),
+        },
+      });
+      await sleep(1000);
+      previousTimerSeconds = timeToEnroll;
+      continue;
+    }
+    const elapsedSeconds = Math.max(0, Math.ceil((observedAt - startedAt) / 1000));
     const remainingSeconds = Math.max(0, timeoutSeconds - elapsedSeconds);
     const cannotWait =
-      selected.enrollmentDeadlineExpired || timeToEnroll === null || timeToEnroll === undefined || timeToEnroll > remainingSeconds;
+      selected.enrollmentDeadlineExpired || !hasTimer || timeToEnroll > remainingSeconds;
     if (cannotWait) {
-      if (notOpenIsNoop) {
-        return closedResult({ classType: resolvedClassType, timeToEnroll, now: now(), timezone });
+      if (notOpenIsNoop && !hasWaited) {
+        await emitTrace({
+          level: "info",
+          scope: "regybox",
+          code: "class_not_open",
+          message: hasTimer
+            ? `Enrollment opens in ${timeToEnroll} seconds, beyond this run's wait window`
+            : "Class is not open and has no enrollment countdown",
+          data: { timerSeconds: timeToEnroll, remainingSeconds },
+        });
+        return closedResult({ classType: resolvedClassType, timeToEnroll, now: observedAt, timezone });
       }
       if (selected.enrollmentDeadlineExpired || timeToEnroll === null || timeToEnroll === undefined) {
         throw new ClassNotOpenError();
       }
       throw new RegyboxTimeoutError(timeoutSeconds, { timeToEnroll });
     }
-    // One long sleep gets near the opening, then short polls avoid spending
-    // dozens of Worker subrequests on a server-side countdown.
-    const waitSeconds = timeToEnroll > 10 ? timeToEnroll - 10 : Math.min(2, Math.max(1, timeToEnroll));
+    const waitSeconds = timeToEnroll > 60 ? 60 : timeToEnroll > 10 ? 10 : 1;
+    hasWaited = true;
+    await emitTrace({
+      level: "info",
+      scope: "regybox",
+      code: "enrollment_wait",
+      message: `Opening in ${timeToEnroll} seconds; retrying in ${waitSeconds} second${waitSeconds === 1 ? "" : "s"}`,
+      data: { timerSeconds: timeToEnroll, waitSeconds, remainingSeconds },
+    });
+    previousTimerSeconds = timeToEnroll;
     await sleep(waitSeconds * 1000);
   }
-  if (notOpenIsNoop) {
-    return closedResult({
-      classType: lastSelected?.name ?? classTypes[0],
-      timeToEnroll: lastSelected?.timeToEnroll ?? null,
-      now: now(),
-      timezone,
-    });
-  }
+  await emitTrace({
+    level: "error",
+    scope: "regybox",
+    code: "enrollment_wait_timeout",
+    message: `Timed out after waiting ${timeoutSeconds} seconds for enrollment to open`,
+    data: { fetchCount: fetches, timeoutSeconds },
+  });
   throw new RegyboxTimeoutError(timeoutSeconds);
 }

--- a/cloudflare/regybox-scheduler/src/runs.js
+++ b/cloudflare/regybox-scheduler/src/runs.js
@@ -1,0 +1,316 @@
+const RUN_INDEX_KEY = "regybox:v1:runs:index";
+const RUN_PREFIX = "regybox:v1:run:";
+const RUN_TTL_SECONDS = 7 * 24 * 60 * 60;
+const MAX_RUN_SUMMARIES = 400;
+const MAX_TRACE_EVENTS = 500;
+const MAX_MESSAGE_LENGTH = 600;
+
+const LEVELS = new Set(["debug", "info", "warn", "error"]);
+const STATUSES = new Set(["running", "success", "noop", "partial", "failure"]);
+const DATA_FIELDS = new Set([
+  "attempt",
+  "cacheAgeMs",
+  "cacheState",
+  "classDate",
+  "classTime",
+  "classType",
+  "durationMs",
+  "decision",
+  "elapsedMs",
+  "enrollmentOpensAt",
+  "errorCode",
+  "eventCount",
+  "httpStatus",
+  "mode",
+  "nextRetryMs",
+  "operation",
+  "outcome",
+  "plannedOperations",
+  "poll",
+  "remainingMs",
+  "reason",
+  "refreshDueAt",
+  "timeToEnroll",
+  "timerSeconds",
+  "previousTimerSeconds",
+  "endpointPath",
+  "actionCount",
+  "buttonCount",
+  "attributeNames",
+  "classNames",
+  "fetchCount",
+  "fetchLimit",
+  "isOpen",
+  "userIsEnrolled",
+  "isFull",
+  "enrollmentDeadlineExpired",
+  "remainingSeconds",
+  "waitSeconds",
+  "timeoutSeconds",
+  "graceRemainingSeconds",
+  "graceSeconds",
+]);
+
+function parseObject(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function safeText(value, limit = MAX_MESSAGE_LENGTH) {
+  return String(value ?? "")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\b(?:authorization|cookie|set-cookie)\s*[:=]\s*[^\r\n]+/gi, "[redacted credential]")
+    .replace(/\b(?:bearer|basic)\s+[a-z0-9._~+/=-]+/gi, "[redacted credential]")
+    .replace(
+      /(["']?(?:PHPSESSID|regybox_user|password|token|secret|cookie)["']?\s*[:=]\s*)["']?[^"',}\s;]+["']?/gi,
+      "$1[redacted]",
+    )
+    .replace(/\b[\w.+-]+@[\w.-]+\.[a-z]{2,}\b/gi, "[redacted email]")
+    .replace(/https?:\/\/[^\s<>"']+/gi, "[redacted URL]")
+    .replace(/([?&][\w.-]+=)[^&\s]+/g, "$1[redacted]")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+}
+
+function safeScalar(value) {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return safeText(value, 200);
+  }
+  return undefined;
+}
+
+function safeEndpointPath(value) {
+  try {
+    return safeText(new URL(String(value), "https://regybox.invalid").pathname, 200);
+  } catch {
+    return undefined;
+  }
+}
+
+function safeData(data) {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return undefined;
+  }
+  const result = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (!DATA_FIELDS.has(key)) {
+      continue;
+    }
+    if (key === "endpointPath") {
+      const pathname = safeEndpointPath(value);
+      if (pathname) result[key] = pathname;
+      continue;
+    }
+    if (Array.isArray(value) && ["attributeNames", "classNames"].includes(key)) {
+      result[key] = value.slice(0, 20).map((item) => safeText(item, 100)).filter(Boolean);
+      continue;
+    }
+    const sanitized = safeScalar(value);
+    if (sanitized !== undefined) {
+      result[key] = sanitized;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function safeOperation(operation) {
+  if (!operation || typeof operation !== "object" || Array.isArray(operation)) {
+    return null;
+  }
+  const safe = {
+    operation: operation.operation === "unenroll" ? "unenroll" : operation.operation === "calendar" ? "calendar" : "enroll",
+    outcome: safeText(operation.outcome, 30),
+  };
+  for (const [key, limit] of [["classDate", 20], ["classTime", 10], ["classType", 200], ["errorCode", 100]]) {
+    const value = safeText(operation[key], limit);
+    if (value) {
+      safe[key] = value;
+    }
+  }
+  return safe;
+}
+
+function randomRunId() {
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(18));
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function runKey(id) {
+  return `${RUN_PREFIX}${id}`;
+}
+
+function summaryFor(record) {
+  return {
+    id: record.id,
+    status: record.status,
+    scheduledAt: record.scheduledAt,
+    startedAt: record.startedAt,
+    ...(record.finishedAt ? { finishedAt: record.finishedAt } : {}),
+    ...(Number.isFinite(record.durationMs) ? { durationMs: record.durationMs } : {}),
+    mode: record.mode,
+    plannedOperations: record.plannedOperations,
+    operations: record.operations,
+    traceTruncated: record.traceTruncated,
+  };
+}
+
+async function readIndex(kv) {
+  const parsed = parseObject(await kv.get(RUN_INDEX_KEY));
+  return Array.isArray(parsed?.runs) ? parsed.runs : [];
+}
+
+async function writeRecord(kv, record) {
+  await kv.put(runKey(record.id), JSON.stringify(record), { expirationTtl: RUN_TTL_SECONDS });
+}
+
+async function upsertIndex(kv, record) {
+  const existing = await readIndex(kv);
+  const retentionBoundary = Date.parse(record.startedAt) - RUN_TTL_SECONDS * 1000;
+  const runs = [
+    summaryFor(record),
+    ...existing.filter((run) =>
+      run?.id !== record.id && Date.parse(run?.startedAt) >= retentionBoundary,
+    ),
+  ]
+    .slice(0, MAX_RUN_SUMMARIES);
+  await kv.put(RUN_INDEX_KEY, JSON.stringify({ runs }), { expirationTtl: RUN_TTL_SECONDS });
+}
+
+function consoleMethod(level) {
+  if (level === "error") return console.error;
+  if (level === "warn") return console.warn;
+  return console.log;
+}
+
+export function outcomeStatus(operations, failed = false) {
+  if (failed) return "failure";
+  if (!Array.isArray(operations) || operations.length === 0) return "noop";
+  const failures = operations.filter((operation) => operation?.outcome === "failure").length;
+  if (failures === operations.length) return "failure";
+  if (failures > 0) return "partial";
+  if (operations.some((operation) => ["success", "dispatched"].includes(operation?.outcome))) {
+    return "success";
+  }
+  return "noop";
+}
+
+export async function createRunRecorder({
+  kv,
+  mode,
+  scheduledAt,
+  now = () => Date.now(),
+  id = randomRunId(),
+}) {
+  if (!kv || !/^[a-f0-9]{36}$/.test(id)) {
+    throw new Error("A KV binding and valid 36-character run ID are required");
+  }
+  const startedMs = now();
+  const record = {
+    version: 1,
+    id,
+    status: "running",
+    scheduledAt: new Date(Number.isFinite(scheduledAt) ? scheduledAt : startedMs).toISOString(),
+    startedAt: new Date(startedMs).toISOString(),
+    mode: safeText(mode || "unconfigured", 30),
+    plannedOperations: 0,
+    operations: [],
+    trace: [],
+    traceTruncated: false,
+  };
+  await writeRecord(kv, record);
+  await upsertIndex(kv, record);
+
+  const persist = async () => {
+    await writeRecord(kv, record);
+    await upsertIndex(kv, record);
+  };
+
+  return {
+    id,
+    get record() {
+      return structuredClone(record);
+    },
+    trace({ level = "info", scope = "run", operationIndex, code = "event", message, data } = {}) {
+      const atMs = now();
+      const event = {
+        at: new Date(atMs).toISOString(),
+        elapsedMs: Math.max(0, atMs - startedMs),
+        level: LEVELS.has(level) ? level : "info",
+        scope: safeText(scope, 60) || "run",
+        ...(Number.isInteger(operationIndex) && operationIndex >= 0 ? { operationIndex } : {}),
+        code: safeText(code, 100) || "event",
+        message: safeText(message),
+      };
+      const sanitizedData = safeData(data);
+      if (sanitizedData) event.data = sanitizedData;
+      consoleMethod(event.level)(`regybox: [run ${id}] ${event.message}`, sanitizedData ?? "");
+      if (record.trace.length < MAX_TRACE_EVENTS) {
+        record.trace.push(event);
+      } else {
+        record.traceTruncated = true;
+      }
+      return event;
+    },
+    async setPlan(plannedOperations) {
+      record.plannedOperations = Math.max(0, Number.parseInt(plannedOperations, 10) || 0);
+      await persist();
+    },
+    async finalize({ status, operations = [], errorCode } = {}) {
+      const finishedMs = now();
+      record.status = STATUSES.has(status) && status !== "running"
+        ? status
+        : outcomeStatus(operations, Boolean(errorCode));
+      record.finishedAt = new Date(finishedMs).toISOString();
+      record.durationMs = Math.max(0, finishedMs - startedMs);
+      record.operations = operations.map(safeOperation).filter(Boolean);
+      if (errorCode) record.errorCode = safeText(errorCode, 100);
+      await persist();
+      return summaryFor(record);
+    },
+  };
+}
+
+export async function readRuns(kv) {
+  if (!kv) return [];
+  try {
+    return await readIndex(kv);
+  } catch (error) {
+    console.warn("regybox: run index read failed:", error);
+    return [];
+  }
+}
+
+export async function readRun(kv, id) {
+  if (!kv || !/^[a-f0-9]{36}$/.test(String(id))) return null;
+  try {
+    return parseObject(await kv.get(runKey(id)));
+  } catch (error) {
+    console.warn("regybox: run read failed:", error);
+    return null;
+  }
+}
+
+export const runConstants = {
+  RUN_INDEX_KEY,
+  RUN_PREFIX,
+  RUN_TTL_SECONDS,
+  RUN_RETENTION_DAYS: RUN_TTL_SECONDS / (24 * 60 * 60),
+  MAX_RUN_SUMMARIES,
+  MAX_TRACE_EVENTS,
+};

--- a/cloudflare/regybox-scheduler/src/status.js
+++ b/cloudflare/regybox-scheduler/src/status.js
@@ -3,6 +3,7 @@ import { executionMode, readActivity, readLastRun } from "./executor.js";
 import { emailConfigured } from "./notify.js";
 import { RegyboxLoginError, createRegyboxClient } from "./regybox.js";
 import { incidentConstants, readIncident } from "./incidents.js";
+import { readRun, readRuns, runConstants } from "./runs.js";
 
 const STYLES = `
   :root { color-scheme: light dark; }
@@ -27,6 +28,11 @@ const STYLES = `
   .off::before  { content: "\\2796\\00a0 "; }
   .hint { display: block; color: #777; font-size: 0.88rem; margin-top: 0.15rem; }
   footer { margin-top: 2rem; color: #777; font-size: 0.85rem; }
+  a { color: inherit; }
+  table { width: 100%; border-collapse: collapse; margin: 0.5rem 0 1.5rem; }
+  th, td { padding: 0.55rem 0.35rem; text-align: left; vertical-align: top; border-bottom: 1px solid #eee; }
+  th { font-size: 0.85rem; color: #777; }
+  code, pre { white-space: pre-wrap; overflow-wrap: anywhere; }
 `;
 
 function escapeHtml(value) {
@@ -275,12 +281,49 @@ function activityCheck(activity, nowMs) {
   return check(level, text);
 }
 
+function runLevel(status) {
+  if (status === "failure") return "bad";
+  if (status === "partial" || status === "running") return "warn";
+  if (status === "success") return "ok";
+  return "off";
+}
+
+function durationText(durationMs) {
+  if (!Number.isFinite(durationMs)) return "still running";
+  if (durationMs < 1000) return `${durationMs}ms`;
+  const seconds = Math.round(durationMs / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function baseHref(basePath, suffix = "") {
+  const base = String(basePath ?? "").replace(/\/+$/, "");
+  return `${base}${suffix}` || "/";
+}
+
+function runCheck(run, nowMs, basePath) {
+  const when = relativeTime(run.startedAt, nowMs) ?? run.startedAt;
+  const operations = Array.isArray(run.operations) ? run.operations : [];
+  const operationText = operations.length > 0
+    ? operations.map(describeOperation).join("; ")
+    : run.status === "running" ? "run is still in progress" : "nothing to do";
+  return {
+    ...check(
+      runLevel(run.status),
+      `${when} — ${run.status} in ${durationText(run.durationMs)} — ${operationText}`,
+      run.traceTruncated ? "The retained trace reached its 500-event limit." : undefined,
+    ),
+    href: baseHref(basePath, `/runs/${run.id}`),
+  };
+}
+
 export async function buildStatusModel({
   env,
   kv,
   fetchImpl = fetch,
   createClient = createRegyboxClient,
   now = () => Date.now(),
+  basePath = "",
 }) {
   const nowMs = now();
   let mode;
@@ -307,6 +350,12 @@ export async function buildStatusModel({
   } catch {
     activity = [];
   }
+  let runs = [];
+  try {
+    runs = kv ? await readRuns(kv) : [];
+  } catch {
+    runs = [];
+  }
   const sections = [
     { title: "Setup", checks: setupChecks(env) },
     { title: "Live checks", checks: liveChecks },
@@ -319,6 +368,13 @@ export async function buildStatusModel({
     sections.push({
       title: "Recent activity",
       checks: activity.slice(0, 10).map((entry) => activityCheck(entry, nowMs)),
+    });
+  }
+  if (runs.length > 0) {
+    sections.push({
+      title: "Recent runs",
+      checks: runs.slice(0, 10).map((run) => runCheck(run, nowMs, basePath)),
+      moreHref: baseHref(basePath, "/runs"),
     });
   }
   return {
@@ -335,12 +391,12 @@ export function renderStatusPage(model) {
       const rows = section.checks
         .map(
           (item) =>
-            `      <li class="${item.level}">${escapeHtml(item.text)}${
+            `      <li class="${item.level}">${item.href ? `<a href="${escapeHtml(item.href)}">` : ""}${escapeHtml(item.text)}${item.href ? "</a>" : ""}${
               item.hint ? `<span class="hint">${escapeHtml(item.hint)}</span>` : ""
             }</li>`,
         )
         .join("\n");
-      return `    <h2>${escapeHtml(section.title)}</h2>\n    <ul>\n${rows}\n    </ul>`;
+      return `    <h2>${escapeHtml(section.title)}</h2>\n    <ul>\n${rows}\n    </ul>${section.moreHref ? `\n    <p><a href="${escapeHtml(section.moreHref)}">View all retained runs</a></p>` : ""}`;
     })
     .join("\n");
   return `<!doctype html>
@@ -372,7 +428,112 @@ export async function handleStatusRequest(env, kv, options = {}) {
   });
 }
 
-export function renderIncidentPage(incident) {
+function htmlResponse(html, status = 200) {
+  return new Response(html, {
+    status,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+      "x-robots-tag": "noindex, nofollow",
+    },
+  });
+}
+
+export function renderRunsPage(runs, { basePath = "", nowMs = Date.now() } = {}) {
+  const rows = runs.map((run) => {
+    const operations = Array.isArray(run.operations) ? run.operations : [];
+    const summary = operations.length > 0 ? operations.map(describeOperation).join("; ") : "nothing to do";
+    return `    <tr>
+      <td><a href="${escapeHtml(baseHref(basePath, `/runs/${run.id}`))}">${escapeHtml(relativeTime(run.startedAt, nowMs) ?? run.startedAt)}</a></td>
+      <td>${escapeHtml(run.status)}</td>
+      <td>${escapeHtml(durationText(run.durationMs))}</td>
+      <td>${escapeHtml(summary)}</td>
+    </tr>`;
+  }).join("\n");
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>Regybox run history</title>
+<style>${STYLES}</style>
+</head>
+<body>
+  <h1>Regybox run history</h1>
+  <p class="sub">Sanitized timelines are retained for ${runConstants.RUN_RETENTION_DAYS} days.</p>
+  <p><a href="${escapeHtml(baseHref(basePath))}">Back to status</a></p>
+  ${rows ? `<table><thead><tr><th>Started</th><th>Status</th><th>Duration</th><th>Operations</th></tr></thead><tbody>\n${rows}\n  </tbody></table>` : "<p>No retained runs yet.</p>"}
+  <footer>This read-only history never includes credentials, calendar contents, raw HTML, or complete action URLs.</footer>
+</body>
+</html>`;
+}
+
+export function renderRunPage(run, { basePath = "" } = {}) {
+  const operations = Array.isArray(run.operations) ? run.operations : [];
+  const operationRows = operations.map((operation, index) =>
+    `    <tr><td>${index + 1}</td><td>${escapeHtml(describeOperation(operation))}</td><td>${escapeHtml(operation.outcome)}</td></tr>`,
+  ).join("\n");
+  const trace = Array.isArray(run.trace) ? run.trace : [];
+  const traceRows = trace.map((event) => {
+    const data = event.data && Object.keys(event.data).length > 0 ? JSON.stringify(event.data) : "";
+    return `    <tr>
+      <td>${escapeHtml(event.at)}</td>
+      <td>${escapeHtml(`${event.elapsedMs}ms`)}</td>
+      <td>${escapeHtml(event.level)}</td>
+      <td>${escapeHtml(event.scope)}${Number.isInteger(event.operationIndex) ? ` #${event.operationIndex + 1}` : ""}</td>
+      <td><strong>${escapeHtml(event.message)}</strong>${data ? `<span class="hint"><code>${escapeHtml(data)}</code></span>` : ""}</td>
+    </tr>`;
+  }).join("\n");
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>Regybox run details</title>
+<style>${STYLES}</style>
+</head>
+<body>
+  <h1>Regybox run details</h1>
+  <p class="sub">Run ${escapeHtml(run.id)} · ${escapeHtml(run.status)} · ${escapeHtml(durationText(run.durationMs))}</p>
+  <p><a href="${escapeHtml(baseHref(basePath, "/runs"))}">Back to run history</a></p>
+  <dl>
+    <dt>Scheduled</dt><dd>${escapeHtml(run.scheduledAt)}</dd>
+    <dt>Started</dt><dd>${escapeHtml(run.startedAt)}</dd>
+    ${run.finishedAt ? `<dt>Finished</dt><dd>${escapeHtml(run.finishedAt)}</dd>` : ""}
+    <dt>Mode</dt><dd>${escapeHtml(run.mode)}</dd>
+  </dl>
+  <h2>Operations</h2>
+  ${operationRows ? `<table><thead><tr><th>#</th><th>Summary</th><th>Outcome</th></tr></thead><tbody>\n${operationRows}\n  </tbody></table>` : "<p>No operations were planned.</p>"}
+  <h2>Timeline</h2>
+  ${traceRows ? `<table><thead><tr><th>Time</th><th>Elapsed</th><th>Level</th><th>Scope</th><th>Event</th></tr></thead><tbody>\n${traceRows}\n  </tbody></table>` : "<p>No trace events were retained.</p>"}
+  ${run.traceTruncated ? `<p class="warn">Trace truncated after ${runConstants.MAX_TRACE_EVENTS} events.</p>` : ""}
+  <footer>This page is read-only. Trace fields are allowlisted and sanitized before storage.</footer>
+</body>
+</html>`;
+}
+
+export async function handleRunsRequest(kv, options = {}) {
+  return htmlResponse(renderRunsPage(await readRuns(kv), options));
+}
+
+export async function handleRunRequest(kv, id, options = {}) {
+  const run = await readRun(kv, id);
+  if (!run) {
+    return new Response("Run not found or expired.", {
+      status: 404,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+        "x-robots-tag": "noindex, nofollow",
+      },
+    });
+  }
+  return htmlResponse(renderRunPage(run, options));
+}
+
+export function renderIncidentPage(incident, { basePath = "" } = {}) {
   const rows = [
     ["Time", incident.timestamp],
     ["Operation", incident.operation],
@@ -412,12 +573,13 @@ export function renderIncidentPage(incident) {
   <dl>
 ${details}
   </dl>
+  ${incident.runId ? `<p><a href="${escapeHtml(baseHref(basePath, `/runs/${incident.runId}`))}">View the complete run timeline</a></p>` : ""}
   <footer>This page is read-only. It never stores or displays credentials, full action URLs, or query tokens.</footer>
 </body>
 </html>`;
 }
 
-export async function handleIncidentRequest(kv, id) {
+export async function handleIncidentRequest(kv, id, options = {}) {
   const incident = await readIncident(kv, id);
   if (!incident) {
     return new Response("Incident not found or expired.", {
@@ -429,7 +591,7 @@ export async function handleIncidentRequest(kv, id) {
       },
     });
   }
-  return new Response(renderIncidentPage(incident), {
+  return new Response(renderIncidentPage(incident, options), {
     headers: {
       "content-type": "text/html; charset=utf-8",
       "cache-control": "no-store",

--- a/cloudflare/regybox-scheduler/test/executor.test.js
+++ b/cloudflare/regybox-scheduler/test/executor.test.js
@@ -163,6 +163,39 @@ test("not_open without an opening timer deliberately does not update cached stat
   assert.equal((await readLastRun(kv)).operations[0].outcome, "noop");
 });
 
+test("a due not-open cache cannot be poisoned by a multi-day opening jump", async () => {
+  const cacheKey = "regybox:v1:calendar:test";
+  const originalState = {
+    state: "not_open",
+    enrollmentOpensAt: "2026-07-19T17:29:59.000Z",
+    lastCheckedAt: "2026-07-19T16:58:00.000Z",
+  };
+  const kv = makeKv(new Map([[cacheKey, JSON.stringify(originalState)]]));
+  const failures = [];
+
+  const summary = await executePlan({
+    env: workerEnv,
+    kv,
+    dispatches: [dispatch({ cacheKey })],
+    now: () => Date.parse("2026-07-19T17:30:01.000Z"),
+    createClient: fakeClient,
+    runOperationImpl: async () => ({
+      status: "noop",
+      classType: "WOD",
+      cacheState: "not_open",
+      enrollmentOpensAt: "2026-07-22T04:59:59.000Z",
+      lastCheckedAt: "2026-07-19T17:30:01.000Z",
+    }),
+    onFailure: async (failure) => failures.push(failure),
+  });
+
+  assert.equal(summary.operations[0].outcome, "failure");
+  assert.equal(summary.operations[0].errorCode, "unparseable_response");
+  assert.equal(failures[0].error.name, "UnparseableError");
+  assert.deepEqual(JSON.parse(await kv.get(cacheKey)), originalState);
+  assert.equal(kv.writes.some(({ key }) => key === cacheKey), false);
+});
+
 test("one operation failure leaves state untouched and does not prevent later operations", async () => {
   const kv = makeKv();
   const failures = [];

--- a/cloudflare/regybox-scheduler/test/incidents.test.js
+++ b/cloudflare/regybox-scheduler/test/incidents.test.js
@@ -84,7 +84,9 @@ test("incident records are short-lived, sanitized, and render read-only", async 
     JSON.stringify(record),
     /<html|<body|<b>|private-secret|class-secret|basic\.ics|private\.ics|marca_aulas\.php\?|top-secret|token=abc|json-secret|bearer-secret|php-secret|id_aula=123/,
   );
-  assert.deepEqual(record.parserDiagnostics.actionEndpoints, ["[redacted action URL]"]);
+  assert.deepEqual(record.parserDiagnostics.actionEndpoints, [
+    "/app/app_nova/php/aulas/marca_aulas.php",
+  ]);
 
   const response = await handleIncidentRequest(kv, id);
   assert.equal(response.status, 200);

--- a/cloudflare/regybox-scheduler/test/notify.test.js
+++ b/cloudflare/regybox-scheduler/test/notify.test.js
@@ -125,6 +125,26 @@ test("failure email includes the short-lived incident link when available", () =
   );
 });
 
+test("result emails can link directly to the retained run timeline", () => {
+  const runUrl = "https://worker.example.test/regybox/runs/0123456789abcdef0123456789abcdef0123";
+  const success = composeEmail({
+    kind: "success",
+    operation: "enroll",
+    classSummary: "WOD on 2026-07-12 at 06:30",
+    runUrl,
+  });
+  const failure = composeEmail({
+    kind: "failure",
+    operation: "enroll",
+    classSummary: "WOD on 2026-07-12 at 06:30",
+    payload: failurePayload,
+    runUrl,
+  });
+
+  assert.match(success.body, new RegExp(`Run details: ${runUrl}`));
+  assert.match(failure.body, new RegExp(`Run timeline: ${runUrl}`));
+});
+
 test("failure technical details are capped at the Python appendix limit", () => {
   const technicalMessage = Array.from({ length: 13 }, (_, index) => `line ${index + 1}`).join("\n");
   const email = composeEmail({

--- a/cloudflare/regybox-scheduler/test/regybox.test.js
+++ b/cloudflare/regybox-scheduler/test/regybox.test.js
@@ -174,9 +174,11 @@ test("client sends the Python-compatible session and class requests", async () =
 test("client retries bounded statuses, handles login expiry, and parses action responses", async () => {
   let calls = 0;
   const waits = [];
+  const traces = [];
   const client = createRegyboxClient({
     phpsessid: "session", regyboxUser: "123", retryTotal: 2, retryBackoffMs: 3,
     sleep: async (milliseconds) => waits.push(milliseconds),
+    onTrace: async (event) => traces.push(event),
     fetchImpl: async () => {
       calls += 1;
       return calls < 3 ? new Response("retry", { status: 503 }) : new Response('<script>parent.msg_toast_icon("Inscrito", "ok");</script>');
@@ -185,6 +187,9 @@ test("client retries bounded statuses, handles login expiry, and parses action r
   assert.deepEqual(await client.enroll("php/aulas/marca_aulas.php?id=1"), { message: "Inscrito", userIsWaitlisted: false });
   assert.equal(calls, 3);
   assert.deepEqual(waits, [3, 6]);
+  assert.equal(traces.filter((event) => event.code === "regybox_request_retry").length, 2);
+  assert.ok(traces.every((event) => event.data.endpointPath === "/app/app_nova/php/aulas/marca_aulas.php"));
+  assert.doesNotMatch(JSON.stringify(traces), /id=1|PHPSESSID|session/);
   const expired = createRegyboxClient({
     phpsessid: "session", regyboxUser: "123", retryTotal: 0,
     fetchImpl: async () => new Response("app/app_nova/login.php"),
@@ -224,6 +229,10 @@ function makeStubClient(responses) {
     async enroll(url) { calls.enroll.push(url); return { message: "OK", userIsWaitlisted: false }; },
     async unenroll(url) { calls.unenroll.push(url); return { message: "OK", userIsWaitlisted: false }; },
   };
+}
+
+function withTimer(html, seconds) {
+  return html.replace(/(<input\b[^>]*\bclass="[^"]*\btimers\b[^"]*"[^>]*\bvalue=")\d+("[^>]*>)/i, `$1${seconds}$2`);
 }
 
 test("runOperation retries a transient empty class list like Python's get_classes", async () => {
@@ -323,10 +332,31 @@ test("action controls are classified by endpoint instead of CSS classes", async 
     '<button class="button color-green" onclick="php/aulas/class_details.php?id=private">Help</button>$1',
   );
   assert.ok(parseClass(withColoredHelpButton).enrollUrl?.includes("/marca_aulas.php?"));
+
+  const literalGreaterThanInOnclick = open.replace(
+    "javascript:load_script",
+    "javascript:if (1 > 0) load_script",
+  );
+  assert.ok(parseClass(literalGreaterThanInOnclick).enrollUrl?.includes("/marca_aulas.php?"));
 });
 
 test("unknown and ambiguous class action endpoints fail with secret-safe diagnostics", async () => {
   const open = await fixture("open.html");
+  const malformed = open.replace(/\bonclick="[^"]*"/, 'onclick="show_booking_dialog()"');
+  assert.throws(
+    () => parseClass(malformed),
+    (error) => {
+      assert.ok(error instanceof UnparseableError);
+      assert.match(error.message, /recognizable class action/);
+      assert.deepEqual(error.safeDiagnostics, {
+        actionEndpoints: [],
+        unknownActionEndpoints: [],
+        malformedBookingControls: 1,
+      });
+      return true;
+    },
+  );
+
   const unknown = open.replace("marca_aulas.php", "new_booking_action.php");
   assert.throws(
     () => parseClass(unknown),
@@ -435,6 +465,126 @@ test("runOperation waits within the Worker poll cap and returns structured not-o
   });
   assert.match(noop.enrollmentOpensAt, /^2024-07-01T/);
   assert.match(noop.lastCheckedAt, /^2024-07-01T/);
+});
+
+test("runOperation matches Python polling cadence at the enrollment boundary", async () => {
+  const closed = await fixture("not_yet_open.html");
+  const open = (await fixture("open.html")).replaceAll("06:30", "07:30").replaceAll("07:20", "08:20");
+  let clock = Date.parse("2024-07-01T00:00:00Z");
+  const waits = [];
+  const traces = [];
+  const client = makeStubClient([
+    withTimer(closed, 58),
+    withTimer(closed, 4),
+    withTimer(closed, 3),
+    withTimer(closed, 2),
+    open,
+  ]);
+
+  const result = await runOperation({
+    client,
+    classDate: "2024-07-01",
+    classTime: "07:30",
+    classType: "WOD Rato",
+    timeoutSeconds: 120,
+    now: () => clock,
+    sleep: async (milliseconds) => { waits.push(milliseconds); clock += milliseconds; },
+    onTrace: async (event) => traces.push(event),
+  });
+
+  assert.equal(result.status, "success");
+  assert.deepEqual(waits, [10_000, 1_000, 1_000, 1_000]);
+  assert.ok(traces.some((event) => event.message === "Opening in 4 seconds; retrying in 1 second"));
+  assert.equal(client.calls.fetch, 5);
+});
+
+test("runOperation treats a post-countdown timer rollover as an inconsistency and keeps polling", async () => {
+  const closed = await fixture("not_yet_open.html");
+  const open = (await fixture("open.html")).replaceAll("06:30", "07:30").replaceAll("07:20", "08:20");
+  let clock = Date.parse("2024-07-01T00:00:00Z");
+  const traces = [];
+  const client = makeStubClient([withTimer(closed, 2), withTimer(closed, 213_598), open]);
+
+  const result = await runOperation({
+    client,
+    classDate: "2024-07-01",
+    classTime: "07:30",
+    classType: "WOD Rato",
+    timeoutSeconds: 60,
+    notOpenIsNoop: true,
+    now: () => clock,
+    sleep: async (milliseconds) => { clock += milliseconds; },
+    onTrace: async (event) => traces.push(event),
+  });
+
+  assert.equal(result.status, "success");
+  assert.equal(client.calls.fetch, 3);
+  const anomaly = traces.find((event) => event.code === "opening_boundary_inconsistency");
+  assert.ok(anomaly);
+  assert.equal(anomaly.data.timerSeconds, 213_598);
+  assert.doesNotMatch(JSON.stringify(traces), /id_aula|PHPSESSID|<div/i);
+});
+
+test("runOperation fails instead of caching a timer rollover that persists through grace", async () => {
+  const closed = await fixture("not_yet_open.html");
+  let clock = Date.parse("2024-07-01T00:00:00Z");
+  const client = makeStubClient([withTimer(closed, 1), withTimer(closed, 213_598)]);
+
+  await assert.rejects(
+    runOperation({
+      client,
+      classDate: "2024-07-01",
+      classTime: "07:30",
+      classType: "WOD Rato",
+      timeoutSeconds: 60,
+      notOpenIsNoop: true,
+      now: () => clock,
+      sleep: async (milliseconds) => { clock += milliseconds; },
+    }),
+    (error) => {
+      assert.ok(error instanceof UnparseableError);
+      assert.equal(error.safeDiagnostics.timerSeconds, 213_598);
+      return true;
+    },
+  );
+  assert.equal(client.calls.enroll.length, 0);
+  assert.ok(client.calls.fetch >= 30);
+});
+
+test("runOperation fails at the defensive fetch ceiling and after a waited timeout", async () => {
+  const closed = await fixture("not_yet_open.html");
+  let clock = Date.parse("2024-07-01T00:00:00Z");
+  const pollingClient = makeStubClient([withTimer(closed, 1)]);
+  await assert.rejects(
+    runOperation({
+      client: pollingClient,
+      classDate: "2024-07-01",
+      classTime: "07:30",
+      classType: "WOD Rato",
+      timeoutSeconds: 900,
+      notOpenIsNoop: true,
+      maxPolls: 3,
+      now: () => clock,
+      sleep: async (milliseconds) => { clock += milliseconds; },
+    }),
+    RegyboxTimeoutError,
+  );
+  assert.equal(pollingClient.calls.fetch, 3);
+
+  clock = Date.parse("2024-07-01T00:00:00Z");
+  await assert.rejects(
+    runOperation({
+      client: makeStubClient([withTimer(closed, 1)]),
+      classDate: "2024-07-01",
+      classTime: "07:30",
+      classType: "WOD Rato",
+      timeoutSeconds: 2,
+      notOpenIsNoop: true,
+      now: () => clock,
+      sleep: async (milliseconds) => { clock += milliseconds; },
+    }),
+    RegyboxTimeoutError,
+  );
 });
 
 test("runOperation preserves closed, overbooked, and unenroll behavior", async () => {

--- a/cloudflare/regybox-scheduler/test/runs.test.js
+++ b/cloudflare/regybox-scheduler/test/runs.test.js
@@ -1,0 +1,320 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { executePlan } from "../src/executor.js";
+import {
+  createRunRecorder,
+  outcomeStatus,
+  readRun,
+  readRuns,
+  runConstants,
+} from "../src/runs.js";
+import {
+  buildStatusModel,
+  handleRunRequest,
+  handleRunsRequest,
+  renderRunPage,
+  renderStatusPage,
+} from "../src/status.js";
+import worker, { handleScheduled } from "../src/index.js";
+
+function makeKv(existing = new Map()) {
+  const writes = [];
+  return {
+    writes,
+    async get(key) {
+      return existing.get(key) ?? null;
+    },
+    async put(key, value, options) {
+      writes.push({ key, value, options });
+      existing.set(key, value);
+    },
+  };
+}
+
+test("run records start durably, sanitize traces, and finalize with retained summaries", async () => {
+  const kv = makeKv();
+  let clock = Date.parse("2026-07-20T10:00:00.000Z");
+  const id = "0123456789abcdef0123456789abcdef0123";
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    const recorder = await createRunRecorder({
+      kv,
+      mode: "worker",
+      scheduledAt: clock - 1000,
+      now: () => clock,
+      id,
+    });
+
+    const running = await readRun(kv, id);
+    assert.equal(running.status, "running");
+    assert.deepEqual((await readRuns(kv)).map((run) => run.id), [id]);
+
+    clock += 4000;
+    await recorder.trace({
+      level: "warn",
+      scope: "poll",
+      code: "timer_jump",
+      message: "cookie=secret user@example.com https://regybox.pt/action.php?token=secret",
+      data: {
+        timerSeconds: 213598,
+        endpointPath: "/action.php?token=secret",
+        rawHtml: "<button>secret</button>",
+        cacheKey: "user@example.com",
+      },
+    });
+    clock += 1000;
+    await recorder.finalize({
+      operations: [{
+        operation: "enroll",
+        classDate: "2026-07-22",
+        classTime: "06:30",
+        classType: "WOD",
+        outcome: "failure",
+        errorCode: "timer_rollover",
+        cacheKey: "secret@example.com",
+      }],
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  const record = await readRun(kv, id);
+  assert.equal(record.status, "failure");
+  assert.equal(record.durationMs, 5000);
+  assert.equal(record.trace.length, 1);
+  const serialized = JSON.stringify(record);
+  assert.ok(!serialized.includes("user@example.com"));
+  assert.ok(!serialized.includes("secret@example.com"));
+  assert.ok(!serialized.includes("rawHtml"));
+  assert.ok(!serialized.includes("cacheKey"));
+  assert.ok(!serialized.includes("regybox.pt"));
+  assert.equal(record.trace[0].data.timerSeconds, 213598);
+  assert.equal(kv.writes.at(-1).options.expirationTtl, runConstants.RUN_TTL_SECONDS);
+});
+
+test("trace retention is capped and marked without hiding terminal status", async () => {
+  const kv = makeKv();
+  const id = "1123456789abcdef0123456789abcdef0123";
+  const recorder = await createRunRecorder({ kv, mode: "worker", id, now: () => 0 });
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    for (let index = 0; index < runConstants.MAX_TRACE_EVENTS + 2; index += 1) {
+      await recorder.trace({ code: "poll", message: `Poll ${index}`, data: { poll: index } });
+    }
+    await recorder.finalize({ operations: [] });
+  } finally {
+    console.log = originalLog;
+  }
+  const record = await readRun(kv, id);
+  assert.equal(record.trace.length, 500);
+  assert.equal(record.traceTruncated, true);
+  assert.equal(record.status, "noop");
+});
+
+test("run index tolerates corruption and retains only the newest 400 summaries", async () => {
+  const oldRuns = Array.from({ length: runConstants.MAX_RUN_SUMMARIES }, (_, index) => ({
+    id: index.toString(16).padStart(36, "0"),
+    status: "noop",
+    startedAt: "2026-07-19T00:00:00.000Z",
+    operations: [],
+  }));
+  const kv = makeKv(new Map([[runConstants.RUN_INDEX_KEY, JSON.stringify({ runs: oldRuns })]]));
+  const id = "abcdef0123456789abcdef0123456789abcd";
+  await createRunRecorder({ kv, mode: "worker", id, now: () => 0 });
+  const runs = await readRuns(kv);
+  assert.equal(runs.length, 400);
+  assert.equal(runs[0].id, id);
+  assert.ok(!runs.some((run) => run.id === oldRuns.at(-1).id));
+
+  const corruptKv = makeKv(new Map([[runConstants.RUN_INDEX_KEY, "not-json"]]));
+  assert.deepEqual(await readRuns(corruptKv), []);
+});
+
+test("run pages are escaped, read-only, routable, and expose chronological traces", async () => {
+  const id = "2123456789abcdef0123456789abcdef0123";
+  const run = {
+    id,
+    status: "partial",
+    scheduledAt: "2026-07-20T09:58:00.000Z",
+    startedAt: "2026-07-20T09:58:01.000Z",
+    finishedAt: "2026-07-20T09:58:05.000Z",
+    durationMs: 4000,
+    mode: "worker",
+    operations: [{ operation: "enroll", classType: "WOD <script>", classDate: "2026-07-22", classTime: "06:30", outcome: "failure" }],
+    trace: [{ at: "2026-07-20T09:58:02.000Z", elapsedMs: 1000, level: "info", scope: "poll", code: "waiting", message: "Opening in 4 seconds; retrying in 1 second", data: { timerSeconds: 4 } }],
+    traceTruncated: false,
+  };
+  const html = renderRunPage(run, { basePath: "/regybox" });
+  assert.ok(!html.includes("<script>"));
+  assert.match(html, /Opening in 4 seconds; retrying in 1 second/);
+  assert.match(html, /href="\/regybox\/runs"/);
+
+  const kv = makeKv(new Map([
+    [`${runConstants.RUN_PREFIX}${id}`, JSON.stringify(run)],
+    [runConstants.RUN_INDEX_KEY, JSON.stringify({ runs: [run] })],
+  ]));
+  const listResponse = await handleRunsRequest(kv, { basePath: "/regybox", nowMs: Date.parse(run.finishedAt) });
+  assert.equal(listResponse.status, 200);
+  assert.equal(listResponse.headers.get("cache-control"), "no-store");
+  assert.match(await listResponse.text(), new RegExp(`/regybox/runs/${id}`));
+  assert.equal((await handleRunRequest(kv, id)).status, 200);
+  assert.equal((await handleRunRequest(kv, "bad-id")).status, 404);
+
+  const model = await buildStatusModel({ env: {}, kv, now: () => Date.parse(run.finishedAt), basePath: "/regybox" });
+  const statusHtml = renderStatusPage(model);
+  assert.match(statusHtml, /Recent runs/);
+  assert.match(statusHtml, new RegExp(`/regybox/runs/${id}`));
+  assert.match(statusHtml, /View all retained runs/);
+
+  const routedList = await worker.fetch(
+    new Request("https://worker.example.test/regybox/runs"),
+    { REGYBOX_STATE: kv },
+    {},
+  );
+  assert.equal(routedList.status, 200);
+  assert.match(await routedList.text(), /Regybox run history/);
+  const routedDetail = await worker.fetch(
+    new Request(`https://worker.example.test/regybox/runs/${id}`),
+    { REGYBOX_STATE: kv },
+    {},
+  );
+  assert.equal(routedDetail.status, 200);
+  assert.match(await routedDetail.text(), /Regybox run details/);
+});
+
+test("recorder write failures never break enrollment execution", async () => {
+  const kv = makeKv();
+  const warnings = [];
+  const originalWarn = console.warn;
+  const originalLog = console.log;
+  console.warn = (...args) => warnings.push(args);
+  console.log = () => {};
+  try {
+    const summary = await executePlan({
+      env: { PHPSESSID: "session", REGYBOX_USER: "user" },
+      kv,
+      dispatches: [{
+        operation: "enroll",
+        inputs: {
+          operation: "enroll",
+          "class-date": "2026-07-22",
+          "class-time": "06:30",
+          "class-type": "WOD",
+          "cache-key": "state",
+        },
+      }],
+      createClient: () => ({ bootstrapSession: async () => {} }),
+      runOperationImpl: async ({ onTrace }) => {
+        await onTrace({ code: "poll", message: "Polling" });
+        return { status: "success" };
+      },
+      recorder: { id: "3123456789abcdef0123456789abcdef0123", trace: async () => { throw new Error("KV unavailable"); } },
+      onResult: async () => {},
+    });
+    assert.equal(summary.operations[0].outcome, "success");
+  } finally {
+    console.warn = originalWarn;
+    console.log = originalLog;
+  }
+  assert.ok(warnings.some(([message]) => message === "regybox: run trace write failed:"));
+});
+
+test("run outcome status distinguishes successful, noop, partial, and failed runs", () => {
+  assert.equal(outcomeStatus([]), "noop");
+  assert.equal(outcomeStatus([{ outcome: "noop" }]), "noop");
+  assert.equal(outcomeStatus([{ outcome: "success" }]), "success");
+  assert.equal(outcomeStatus([{ outcome: "success" }, { outcome: "failure" }]), "partial");
+  assert.equal(outcomeStatus([{ outcome: "failure" }]), "failure");
+});
+
+test("scheduled calendar failures finalize a visible failure timeline", async () => {
+  const kv = makeKv();
+  const originalFetch = globalThis.fetch;
+  const originalLog = console.log;
+  const originalError = console.error;
+  globalThis.fetch = async () => new Response("unavailable", { status: 503 });
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    await assert.rejects(
+      handleScheduled({
+        GITHUB_TOKEN: "token",
+        GITHUB_OWNER: "owner",
+        GITHUB_REPO: "repo",
+        CALENDAR_URL: "https://calendar.example.test/private.ics",
+        REGYBOX_STATE: kv,
+      }, {
+        scheduledAt: Date.parse("2026-07-20T10:28:00.000Z"),
+        now: () => Date.parse("2026-07-20T10:28:01.000Z"),
+      }),
+      /Calendar fetch failed: 503/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.log = originalLog;
+    console.error = originalError;
+  }
+  const summaries = await readRuns(kv);
+  assert.equal(summaries.length, 1);
+  assert.equal(summaries[0].status, "failure");
+  assert.equal(summaries[0].scheduledAt, "2026-07-20T10:28:00.000Z");
+  const run = await readRun(kv, summaries[0].id);
+  assert.deepEqual(run.operations, [{
+    operation: "calendar",
+    outcome: "failure",
+    errorCode: "calendar_or_plan_failure",
+  }]);
+  assert.deepEqual(run.trace.map((event) => event.code), [
+    "calendar_fetch_started",
+    "calendar_or_plan_failed",
+  ]);
+});
+
+test("scheduled execution setup failures never inherit operations from the previous run", async () => {
+  const previousOperations = [{
+    operation: "enroll",
+    classDate: "2026-07-19",
+    classTime: "06:30",
+    classType: "WOD",
+    outcome: "success",
+  }];
+  const kv = makeKv(new Map([["regybox:v1:last_run", JSON.stringify({
+    ranAt: "2026-07-19T05:30:00.000Z",
+    mode: "worker",
+    plannedOperations: 1,
+    operations: previousOperations,
+  })]]));
+  const originalFetch = globalThis.fetch;
+  const originalLog = console.log;
+  const originalError = console.error;
+  globalThis.fetch = async () => new Response("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n");
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    await assert.rejects(
+      handleScheduled({
+        CALENDAR_URL: "https://calendar.example.test/private.ics",
+        CALENDAR_EVENT_NAMES: "Crossfit",
+        CLASS_TYPE: "WOD",
+        REGYBOX_STATE: kv,
+      }, {
+        scheduledAt: Date.parse("2026-07-20T10:28:00.000Z"),
+        now: () => Date.parse("2026-07-20T10:28:01.000Z"),
+      }),
+      /Missing scheduler configuration variables/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.log = originalLog;
+    console.error = originalError;
+  }
+
+  const summaries = await readRuns(kv);
+  assert.equal(summaries[0].status, "failure");
+  const run = await readRun(kv, summaries[0].id);
+  assert.deepEqual(run.operations, []);
+  assert.ok(!JSON.stringify(run).includes("2026-07-19"));
+});

--- a/cloudflare/regybox-scheduler/test/worker.test.js
+++ b/cloudflare/regybox-scheduler/test/worker.test.js
@@ -291,7 +291,7 @@ test("buildPlan sweeps stale enrolled entries across paginated KV listings", asy
   );
 });
 
-test("not-open KV entry skips dispatch before the six-hour refresh boundary", async () => {
+test("not-open KV entry skips dispatch before the five-and-a-half-hour refresh threshold", async () => {
   const key = "regybox:v1:calendar:one-class:2026-06-18T10:30:00.000Z";
   const kv = makeKv(
     new Map([
@@ -322,7 +322,7 @@ test("not-open KV entry skips dispatch before the six-hour refresh boundary", as
     env: baseEnv,
     kv,
     icsText: ics,
-    now: new Date("2026-06-18T05:59:59.999Z"),
+    now: new Date("2026-06-18T05:29:59.999Z"),
   });
 
   assert.deepEqual(plan.dispatches, []);
@@ -441,7 +441,7 @@ test("not-open KV entry dispatches when last check time is invalid", async () =>
   assert.equal(plan.dispatches[0].operation, "enroll");
 });
 
-test("not-open KV entry dispatches at the six-hour refresh boundary", async () => {
+test("not-open KV entry dispatches at the five-and-a-half-hour refresh threshold", async () => {
   const key = "regybox:v1:calendar:one-class:2026-06-18T10:30:00.000Z";
   const kv = makeKv(
     new Map([
@@ -472,11 +472,67 @@ test("not-open KV entry dispatches at the six-hour refresh boundary", async () =
     env: baseEnv,
     kv,
     icsText: ics,
-    now: new Date("2026-06-18T06:00:00Z"),
+    now: new Date("2026-06-18T05:30:00Z"),
   });
 
   assert.equal(plan.dispatches.length, 1);
   assert.equal(plan.dispatches[0].operation, "enroll");
+});
+
+test("half-hour cron cadence retries a not-open class within six hours", async () => {
+  const key = "regybox:v1:calendar:one-class:2026-06-19T10:30:00.000Z";
+  const kv = makeKv(
+    new Map([
+      [
+        key,
+        JSON.stringify({
+          state: "not_open",
+          classDate: "2026-06-19",
+          classTime: "11:30",
+          classType: "WOD",
+          enrollmentOpensAt: "2026-06-20T10:00:00.000Z",
+          lastCheckedAt: "2026-06-18T17:30:01.000Z",
+        }),
+      ],
+    ]),
+  );
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:one-class",
+    "SUMMARY:Crossfit",
+    "DTSTART:20260619T103000Z",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const beforeThreshold = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: ics,
+    now: new Date("2026-06-18T22:58:00.000Z"),
+  });
+  const traces = [];
+  const nextCron = await buildPlan({
+    env: baseEnv,
+    kv,
+    icsText: ics,
+    now: new Date("2026-06-18T23:28:00.000Z"),
+    onTrace: async (event) => traces.push(event),
+  });
+
+  assert.deepEqual(beforeThreshold.dispatches, []);
+  assert.equal(nextCron.dispatches.length, 1);
+  assert.ok(
+    new Date("2026-06-18T23:28:00.000Z").getTime() -
+      new Date("2026-06-18T17:30:01.000Z").getTime() <
+      6 * 60 * 60 * 1000,
+  );
+  const forcedRefresh = traces.find((event) => event.data?.reason === "forced_refresh_due");
+  assert.equal(forcedRefresh.code, "calendar_event_scheduled");
+  assert.equal(forcedRefresh.data.decision, "dispatch");
+  assert.match(forcedRefresh.message, /forced refresh is due/);
+  assert.doesNotMatch(JSON.stringify(traces), /one-class|regybox:v1:calendar/);
 });
 
 test("stale not-open KV entries do not dispatch unenroll", async () => {


### PR DESCRIPTION
- replace regex parsing with parse5 and restore boundary polling parity
- reject timer rollovers and guarantee six-hour cached retries
- add sanitized seven-day run timelines to the status dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Recent runs timeline with run history and detailed trace pages.
  * Added run links to incident pages and success or failure email notifications.
  * Improved status pages with clearer timelines, retention details, and privacy guidance.

* **Bug Fixes**
  * Improved HTML parsing and handling of enrollment timer inconsistencies.
  * Adjusted not-open refresh timing to improve retry behavior.

* **Documentation**
  * Clarified private status-page access requirements and retained-data limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->