### PR TITLE
fix(cloudflare): honor repeated calendar exclusions

### DIFF
--- a/.github/workflows/class_operation.yml
+++ b/.github/workflows/class_operation.yml
@@ -38,6 +38,15 @@ jobs:
     name: Regybox class operation
     runs-on: ubuntu-latest
     steps:
+      - name: Validate calendar guard
+        shell: bash
+        env:
+          CALENDAR_URL: ${{ secrets.CALENDAR_URL }}
+        run: |
+          if [[ -z "${CALENDAR_URL// }" ]]; then
+            echo "::error::CALENDAR_URL is required for scheduler-dispatched operations."
+            exit 1
+          fi
       - name: Regybox class operation
         uses: martimlobao/regybox@main
         with:
@@ -55,6 +64,7 @@ jobs:
           cf-kv-api-token: ${{ secrets.CF_KV_API_TOKEN }}
           phpsessid: ${{ secrets.PHPSESSID }}
           regybox-user: ${{ secrets.REGYBOX_USER }}
+          calendar-url: ${{ secrets.CALENDAR_URL }}
           send-email: true
           email-to: ${{ secrets.EMAIL_TO }}
           email-username: ${{ secrets.EMAIL_USERNAME }}

--- a/cloudflare/regybox-scheduler/src/calendar.js
+++ b/cloudflare/regybox-scheduler/src/calendar.js
@@ -98,8 +98,16 @@ function parseProperties(lines) {
     }
     const [rawName, ...params] = line.slice(0, index).split(";");
     const name = rawName.toUpperCase();
-    props[rawName] = line.slice(index + 1);
-    props[name] = line.slice(index + 1);
+    const value = line.slice(index + 1);
+    // iCalendar permits multiple EXDATE properties. Keep every value so one
+    // later exclusion cannot silently restore an earlier cancelled instance.
+    if (name === "EXDATE" && props[name] !== undefined) {
+      props[name] = `${props[name]},${value}`;
+      props[rawName] = props[name];
+    } else {
+      props[rawName] = value;
+      props[name] = value;
+    }
     props[`${name}_PARAMS`] = params;
   }
   return props;

--- a/cloudflare/regybox-scheduler/test/worker.test.js
+++ b/cloudflare/regybox-scheduler/test/worker.test.js
@@ -764,6 +764,35 @@ test("recurring calendar events respect EXDATE exclusions", () => {
   );
 });
 
+test("recurring calendar events respect every repeated EXDATE property", () => {
+  const ics = [
+    "BEGIN:VCALENDAR",
+    "BEGIN:VEVENT",
+    "UID:weekday-class-with-separate-exdates",
+    "SUMMARY:Crossfit",
+    "DTSTART;TZID=Europe/Lisbon:20260619T063000",
+    "RRULE:FREQ=WEEKLY;BYDAY=FR,MO,TH,TU,WE",
+    "EXDATE;TZID=Europe/Lisbon:20260724T063000",
+    "EXDATE;TZID=Europe/Lisbon:20260720T063000",
+    "EXDATE;TZID=Europe/Lisbon:20260623T063000",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  const events = expandCalendarEvents({
+    icsText: ics,
+    now: new Date("2026-07-23T00:00:00Z"),
+    lookaheadHours: 72,
+    calendarEventNames: ["Crossfit"],
+    timeZone: "Europe/Lisbon",
+  });
+
+  assert.deepEqual(
+    events.map((event) => [event.classDate, event.classTime]),
+    [["2026-07-23", "06:30"]],
+  );
+});
+
 test("moved recurring instance uses override time instead of original slot", () => {
   const ics = [
     "BEGIN:VCALENDAR",

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -45,6 +45,8 @@ def test_class_operation_workflow_exposes_dispatch_and_kv_inputs() -> None:
     assert "cache-key:" in workflow_text
     assert "calendar-fingerprint:" in workflow_text
     assert "calendar-event-name: ${{ inputs.calendar-event-name }}" in workflow_text
+    assert "calendar-url: ${{ secrets.CALENDAR_URL }}" in workflow_text
+    assert 'if [[ -z "${CALENDAR_URL// }" ]]; then' in workflow_text
     assert "timeout-seconds: 900" in workflow_text
     assert "not-open-is-noop: true" in workflow_text
     cache_key_start = workflow_text.index("      cache-key:")


### PR DESCRIPTION
- preserve every repeated EXDATE when expanding recurring events
- require scheduler-dispatched operations to recheck the calendar
- add regression coverage for excluded recurring instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected calendar processing for recurring events with multiple exclusion dates, ensuring only valid class occurrences are scheduled.
  * Added validation to prevent class operations from running when the calendar address is unavailable.

* **Tests**
  * Added coverage for recurring events with multiple exclusion dates.
  * Expanded workflow validation checks for calendar configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->