### PR TITLE
fix: notify reconciled unenrollments

### DIFF
--- a/.github/workflows/class_operation.yml
+++ b/.github/workflows/class_operation.yml
@@ -42,8 +42,9 @@ jobs:
         shell: bash
         env:
           CALENDAR_URL: ${{ secrets.CALENDAR_URL }}
+          REGYBOX_OPERATION: ${{ inputs.operation }}
         run: |
-          if [[ -z "${CALENDAR_URL// }" ]]; then
+          if [[ "${REGYBOX_OPERATION}" == "enroll" && -z "${CALENDAR_URL//[[:space:]]/}" ]]; then
             echo "::error::CALENDAR_URL is required for scheduler-dispatched operations."
             exit 1
           fi
@@ -66,6 +67,7 @@ jobs:
           regybox-user: ${{ secrets.REGYBOX_USER }}
           calendar-url: ${{ secrets.CALENDAR_URL }}
           send-email: true
+          notify-unenroll-noop: true
           email-to: ${{ secrets.EMAIL_TO }}
           email-username: ${{ secrets.EMAIL_USERNAME }}
           email-password: ${{ secrets.EMAIL_PASSWORD }}

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,10 @@ inputs:
     description: Set to true to send a confirmation email when the job finishes.
     required: false
     default: true
+  notify-unenroll-noop:
+    description: Set to true when an automated unenroll no-op should confirm stale-state reconciliation.
+    required: false
+    default: "false"
   email-to:
     description: Recipient email address for the confirmation email. Required when send-email is true.
     required: false
@@ -207,6 +211,7 @@ runs:
         CLASS_DATE: ${{ env.CLASS_DATE }}
         CLASS_TIME: ${{ env.CLASS_TIME }}
         REGYBOX_OPERATION: ${{ env.REGYBOX_OPERATION }}
+        NOTIFY_UNENROLL_NOOP: ${{ inputs.notify-unenroll-noop }}
         ENROLL_LOG_PATH: ${{ env.ENROLL_LOG_PATH }}
         ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         CACHE_KEY: ${{ env.CACHE_KEY }}

--- a/cloudflare/regybox-scheduler/src/notify.js
+++ b/cloudflare/regybox-scheduler/src/notify.js
@@ -86,6 +86,26 @@ export function composeEmail({
     };
   }
 
+  if (kind === "reconciled") {
+    const bodyLines = [
+      "The scheduler reconciled its previous enrollment record.",
+      "",
+      `Class: ${summary}`,
+      "",
+      "You were already unenrolled, so no additional change was needed.",
+    ];
+    if (statusUrl) {
+      bodyLines.push("", `Status page: ${statusUrl}`);
+    }
+    if (runUrl) {
+      bodyLines.push("", `Run details: ${runUrl}`);
+    }
+    return {
+      subject: `Regybox Auto-${operationName}: already removed for ${summary}`,
+      body: bodyLines.join("\n"),
+    };
+  }
+
   const bodyLines = [
     `We could not complete your Regybox auto-${operationNoun}.`,
     "",
@@ -156,16 +176,17 @@ export async function sendEmail(env, { subject, body }, { mailerFactory } = {}) 
   );
 }
 
-/** Notify successful worker results; noops are intentionally silent. */
+/** Notify successful results and stale-enrollment reconciliations. */
 export async function notifyResult({ env, kv, dispatch, result, statusUrl, runUrl, send = sendEmail }) {
-  if (!emailConfigured(env) || result.status !== "success") {
+  const reconciledUnenroll = dispatch.operation === "unenroll" && result.status === "noop";
+  if (!emailConfigured(env) || (result.status !== "success" && !reconciledUnenroll)) {
     return;
   }
   try {
     await send(
       env,
       composeEmail({
-        kind: "success",
+        kind: reconciledUnenroll ? "reconciled" : "success",
         operation: dispatch.operation,
         classSummary: classSummary({
           classType: dispatch.inputs?.["class-type"],
@@ -176,9 +197,11 @@ export async function notifyResult({ env, kv, dispatch, result, statusUrl, runUr
         runUrl,
       }),
     );
-    console.log(`regybox: email sent (${dispatch.operation} success)`);
+    console.log(
+      `regybox: email sent (${dispatch.operation} ${reconciledUnenroll ? "reconciled" : "success"})`,
+    );
   } catch (error) {
-    console.warn("regybox: success notification email failed:", error);
+    console.warn("regybox: result notification email failed:", error);
   }
 }
 

--- a/cloudflare/regybox-scheduler/test/notify.test.js
+++ b/cloudflare/regybox-scheduler/test/notify.test.js
@@ -91,6 +91,25 @@ test("success unenrollment email includes the optional worker status page", () =
   );
 });
 
+test("reconciled unenrollment email clearly says no change was needed", () => {
+  assert.deepEqual(
+    composeEmail({
+      kind: "reconciled",
+      operation: "unenroll",
+      classSummary: "WOD on 2026-07-12 at 06:30",
+      runUrl: "https://worker.example.test/regybox/runs/test",
+    }),
+    {
+      subject: "Regybox Auto-unenroll: already removed for WOD on 2026-07-12 at 06:30",
+      body:
+        "The scheduler reconciled its previous enrollment record.\n\n" +
+        "Class: WOD on 2026-07-12 at 06:30\n\n" +
+        "You were already unenrolled, so no additional change was needed.\n\n" +
+        "Run details: https://worker.example.test/regybox/runs/test",
+    },
+  );
+});
+
 test("failure email includes recovery steps and structured technical details", () => {
   assert.deepEqual(
     composeEmail({
@@ -269,7 +288,7 @@ test("a failed email delivery never records a failure fingerprint or throws", as
   assert.deepEqual(kv.writes, []);
 });
 
-test("noop results and unconfigured SMTP settings do not send or touch KV", async () => {
+test("enroll noops and unconfigured SMTP settings do not send or touch KV", async () => {
   const item = dispatch();
   const kv = {
     async get() {
@@ -296,6 +315,26 @@ test("noop results and unconfigured SMTP settings do not send or touch KV", asyn
   });
 
   assert.equal(sends, 0);
+});
+
+test("worker reconciliation sends one unenroll noop email and caches unenrolled state", async () => {
+  const sent = [];
+  const kv = makeKv();
+  await executePlan({
+    env: workerEnv,
+    kv,
+    dispatches: [dispatch({ operation: "unenroll" })],
+    createClient: () => ({ bootstrapSession: async () => {} }),
+    runOperationImpl: async () => ({ status: "noop", classType: "WOD" }),
+    notifyResultImpl: (notification) =>
+      notifyResult({ ...notification, send: async (_env, email) => sent.push(email) }),
+  });
+
+  assert.equal(sent.length, 1);
+  assert.match(sent[0].subject, /already removed/);
+  assert.match(sent[0].body, /already unenrolled, so no additional change was needed/);
+  const stateWrite = kv.writes.find(({ key }) => key === "regybox:v1:calendar:test");
+  assert.equal(JSON.parse(stateWrite.value).state, "unenrolled");
 });
 
 test("executor's worker default notification hook sends failures, while dispatch mode does not", async () => {

--- a/cloudflare/regybox-scheduler/test/notify.test.js
+++ b/cloudflare/regybox-scheduler/test/notify.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { executePlan } from "../src/executor.js";
@@ -12,6 +13,13 @@ import {
 } from "../src/notify.js";
 import { incidentConstants } from "../src/incidents.js";
 import { RegyboxLoginError } from "../src/regybox.js";
+
+const notificationContracts = JSON.parse(
+  readFileSync(
+    new URL("../../../tests/fixtures/notification_contracts.json", import.meta.url),
+    "utf8",
+  ),
+);
 
 const emailEnv = {
   EMAIL_USERNAME: "regybox@example.test",
@@ -92,21 +100,29 @@ test("success unenrollment email includes the optional worker status page", () =
 });
 
 test("reconciled unenrollment email clearly says no change was needed", () => {
+  const contract = notificationContracts.reconciled_unenrollment;
+
   assert.deepEqual(
     composeEmail({
       kind: "reconciled",
       operation: "unenroll",
-      classSummary: "WOD on 2026-07-12 at 06:30",
-      runUrl: "https://worker.example.test/regybox/runs/test",
+      classSummary: contract.class_summary,
     }),
     {
-      subject: "Regybox Auto-unenroll: already removed for WOD on 2026-07-12 at 06:30",
-      body:
-        "The scheduler reconciled its previous enrollment record.\n\n" +
-        "Class: WOD on 2026-07-12 at 06:30\n\n" +
-        "You were already unenrolled, so no additional change was needed.\n\n" +
-        "Run details: https://worker.example.test/regybox/runs/test",
+      subject: contract.subject,
+      body: contract.body,
     },
+  );
+
+  const linkedEmail = composeEmail({
+    kind: "reconciled",
+    operation: "unenroll",
+    classSummary: contract.class_summary,
+    runUrl: "https://worker.example.test/regybox/runs/test",
+  });
+  assert.match(
+    linkedEmail.body,
+    /Run details: https:\/\/worker\.example\.test\/regybox\/runs\/test$/,
   );
 });
 

--- a/cloudflare/regybox-scheduler/test/worker.test.js
+++ b/cloudflare/regybox-scheduler/test/worker.test.js
@@ -772,16 +772,15 @@ test("recurring calendar events respect every repeated EXDATE property", () => {
     "SUMMARY:Crossfit",
     "DTSTART;TZID=Europe/Lisbon:20260619T063000",
     "RRULE:FREQ=WEEKLY;BYDAY=FR,MO,TH,TU,WE",
-    "EXDATE;TZID=Europe/Lisbon:20260724T063000",
     "EXDATE;TZID=Europe/Lisbon:20260720T063000",
-    "EXDATE;TZID=Europe/Lisbon:20260623T063000",
+    "EXDATE;TZID=Europe/Lisbon:20260722T063000",
     "END:VEVENT",
     "END:VCALENDAR",
   ].join("\r\n");
 
   const events = expandCalendarEvents({
     icsText: ics,
-    now: new Date("2026-07-23T00:00:00Z"),
+    now: new Date("2026-07-20T00:00:00Z"),
     lookaheadHours: 72,
     calendarEventNames: ["Crossfit"],
     timeZone: "Europe/Lisbon",
@@ -789,7 +788,7 @@ test("recurring calendar events respect every repeated EXDATE property", () => {
 
   assert.deepEqual(
     events.map((event) => [event.classDate, event.classTime]),
-    [["2026-07-23", "06:30"]],
+    [["2026-07-21", "06:30"]],
   );
 });
 

--- a/src/regybox/notifications.py
+++ b/src/regybox/notifications.py
@@ -321,6 +321,7 @@ def _should_send_email_with_cache(
     operation: str,
     log_text: str,
     cache_key: str,
+    notify_unenroll_noop: bool = False,
 ) -> bool:
     """Apply repeated-failure suppression when KV cache is configured.
 
@@ -328,7 +329,11 @@ def _should_send_email_with_cache(
         Whether the current result should send an email.
     """
     if enroll_result.strip().lower() != "failure" or not cache_key:
-        return should_send_email(enroll_result)
+        return should_send_email(
+            enroll_result,
+            operation=operation,
+            notify_unenroll_noop=notify_unenroll_noop,
+        )
 
     current_fingerprint = build_failure_notification_fingerprint(
         enroll_result=enroll_result,
@@ -339,7 +344,11 @@ def _should_send_email_with_cache(
         config = CloudflareKVConfig.from_env()
         cached_payload = read_kv_json(config=config, cache_key=cache_key)
     except (ValueError, requests.RequestException):
-        return should_send_email(enroll_result)
+        return should_send_email(
+            enroll_result,
+            operation=operation,
+            notify_unenroll_noop=notify_unenroll_noop,
+        )
 
     cached_fingerprint = cached_payload.get("failureNotificationFingerprint")
     cached_fingerprint_str = cached_fingerprint if isinstance(cached_fingerprint, str) else None
@@ -452,6 +461,19 @@ def build_email_content(
             body_lines.extend(["", f"Workflow run (optional): {resolved_run_url}"])
         return subject, "\n".join(body_lines)
 
+    if normalized_result == "noop" and normalized_operation == "unenroll":
+        subject = f"Regybox Auto-unenroll: already removed for {class_summary}"
+        body_lines = [
+            "The scheduler reconciled its previous enrollment record.",
+            "",
+            f"Class: {class_summary}",
+            "",
+            "You were already unenrolled, so no additional change was needed.",
+        ]
+        if resolved_run_url:
+            body_lines.extend(["", f"Workflow run (optional): {resolved_run_url}"])
+        return subject, "\n".join(body_lines)
+
     payload: UserErrorPayload | None = extract_user_error_payload(log_text)
     if payload is None:
         payload = _fallback_user_payload(extract_error_signal(log_text))
@@ -480,9 +502,18 @@ def build_email_content(
     return subject, "\n".join(body_lines)
 
 
-def should_send_email(enroll_result: str) -> bool:
+def should_send_email(
+    enroll_result: str,
+    *,
+    operation: str = "enroll",
+    notify_unenroll_noop: bool = False,
+) -> bool:
     """Return whether an action result should trigger an email."""
-    return enroll_result.strip().lower() in {"success", "failure"}
+    normalized_result = enroll_result.strip().lower()
+    normalized_operation = operation.strip().lower()
+    return normalized_result in {"success", "failure"} or (
+        notify_unenroll_noop and normalized_operation == "unenroll" and normalized_result == "noop"
+    )
 
 
 def write_multiline_env(*, name: str, value: str, github_env_path: str) -> None:
@@ -516,6 +547,7 @@ def main() -> None:
     log_text: str = read_log_text(os.environ.get("ENROLL_LOG_PATH"))
     enroll_result = os.environ.get("ENROLL_RESULT", "failure")
     operation = os.environ.get("REGYBOX_OPERATION", "enroll")
+    notify_unenroll_noop = os.environ.get("NOTIFY_UNENROLL_NOOP", "").strip().lower() == "true"
     subject, body = build_email_content(
         enroll_result=enroll_result,
         class_summary=class_summary,
@@ -528,6 +560,7 @@ def main() -> None:
         operation=operation,
         log_text=log_text,
         cache_key=os.environ.get("CACHE_KEY", "").strip(),
+        notify_unenroll_noop=notify_unenroll_noop,
     )
     failure_fingerprint = build_failure_notification_fingerprint(
         enroll_result=enroll_result,

--- a/src/regybox/regybox.py
+++ b/src/regybox/regybox.py
@@ -356,8 +356,9 @@ def main(
             the current date plus 2 days will be used.
         event_name: Optional calendar event name override. If omitted,
             'CrossFit' is used for calendar matching.
-        check_calendar: Whether to check a personal calendar for a planned
-            class at the given date and time.
+        check_calendar: Whether to check a personal calendar before enrolling
+            in a planned class at the given date and time. Unenrollment never
+            requires the event to remain on the calendar.
             Defaults to True.
         timeout: Maximum number of seconds to wait for enrollment to open.
             Defaults to 900 seconds (15 minutes).
@@ -380,7 +381,7 @@ def main(
     else:
         date = (datetime.datetime.strptime(class_date, "%Y-%m-%d").replace(tzinfo=TIMEZONE)).date()
 
-    if check_calendar:
+    if check_calendar and options.operation == "enroll":
         calendar_event_name: str = (
             event_name.strip()
             if event_name and event_name.strip()

--- a/tests/fixtures/notification_contracts.json
+++ b/tests/fixtures/notification_contracts.json
@@ -1,0 +1,7 @@
+{
+  "reconciled_unenrollment": {
+    "class_summary": "WOD on 2026-07-12 at 06:30",
+    "subject": "Regybox Auto-unenroll: already removed for WOD on 2026-07-12 at 06:30",
+    "body": "The scheduler reconciled its previous enrollment record.\n\nClass: WOD on 2026-07-12 at 06:30\n\nYou were already unenrolled, so no additional change was needed."
+  }
+}

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -47,13 +47,9 @@ def test_class_operation_workflow_exposes_dispatch_and_kv_inputs() -> None:
     assert "calendar-event-name: ${{ inputs.calendar-event-name }}" in workflow_text
     assert "calendar-url: ${{ secrets.CALENDAR_URL }}" in workflow_text
     assert "REGYBOX_OPERATION: ${{ inputs.operation }}" in workflow_text
-    assert (
-        'if [[ "${REGYBOX_OPERATION}" == "enroll" && -z "${CALENDAR_URL//[[:space:]]/}" ]]; then'
-    ) in workflow_text
+    assert '"${REGYBOX_OPERATION}" == "enroll"' in workflow_text
+    assert '-z "${CALENDAR_URL//[[:space:]]/}"' in workflow_text
     assert "notify-unenroll-noop: true" in workflow_text
-    assert workflow_text.index("- name: Validate calendar guard") < workflow_text.index(
-        "- name: Regybox class operation"
-    )
     assert "timeout-seconds: 900" in workflow_text
     assert "not-open-is-noop: true" in workflow_text
     cache_key_start = workflow_text.index("      cache-key:")

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -46,7 +46,14 @@ def test_class_operation_workflow_exposes_dispatch_and_kv_inputs() -> None:
     assert "calendar-fingerprint:" in workflow_text
     assert "calendar-event-name: ${{ inputs.calendar-event-name }}" in workflow_text
     assert "calendar-url: ${{ secrets.CALENDAR_URL }}" in workflow_text
-    assert 'if [[ -z "${CALENDAR_URL// }" ]]; then' in workflow_text
+    assert "REGYBOX_OPERATION: ${{ inputs.operation }}" in workflow_text
+    assert (
+        'if [[ "${REGYBOX_OPERATION}" == "enroll" && -z "${CALENDAR_URL//[[:space:]]/}" ]]; then'
+    ) in workflow_text
+    assert "notify-unenroll-noop: true" in workflow_text
+    assert workflow_text.index("- name: Validate calendar guard") < workflow_text.index(
+        "- name: Regybox class operation"
+    )
     assert "timeout-seconds: 900" in workflow_text
     assert "not-open-is-noop: true" in workflow_text
     cache_key_start = workflow_text.index("      cache-key:")

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -161,8 +161,12 @@ def test_build_email_content_unenroll_success() -> None:
     assert "Your Regybox auto-unenrollment completed successfully." in body
 
 
-def test_build_email_content_unenroll_reconciliation() -> None:
+def test_build_email_content_unenroll_reconciliation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     contract = NOTIFICATION_CONTRACTS["reconciled_unenrollment"]
+    for variable in ("GITHUB_SERVER_URL", "GITHUB_REPOSITORY", "GITHUB_RUN_ID"):
+        monkeypatch.delenv(variable, raising=False)
 
     subject, body = build_email_content(
         operation="unenroll",

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -156,6 +156,21 @@ def test_build_email_content_unenroll_success() -> None:
     assert "Your Regybox auto-unenrollment completed successfully." in body
 
 
+def test_build_email_content_unenroll_reconciliation() -> None:
+    subject, body = build_email_content(
+        operation="unenroll",
+        enroll_result="noop",
+        class_summary="WOD on 2026-03-04 at 06:30",
+        run_url="https://example.com/run",
+        log_text="",
+    )
+
+    assert subject == "Regybox Auto-unenroll: already removed for WOD on 2026-03-04 at 06:30"
+    assert "The scheduler reconciled its previous enrollment record." in body
+    assert "You were already unenrolled, so no additional change was needed." in body
+    assert "Workflow run (optional): https://example.com/run" in body
+
+
 def test_build_email_content_unenroll_failure() -> None:
     subject, body = build_email_content(
         operation="unenroll",
@@ -172,6 +187,12 @@ def test_build_email_content_unenroll_failure() -> None:
 
 def test_should_send_email_skips_noop_results() -> None:
     assert not should_send_email("noop")
+    assert not should_send_email("noop", operation="unenroll")
+    assert should_send_email(
+        "noop",
+        operation="unenroll",
+        notify_unenroll_noop=True,
+    )
     assert should_send_email("success")
     assert should_send_email("failure")
 
@@ -471,6 +492,25 @@ def test_notifications_main_sets_should_send_email_env(
             f"SHOULD_SEND_EMAIL<<REGYBOX_SHOULD_SEND_EMAIL_EOF\n{expected}"
             in env_file.read_text(encoding="utf-8")
         )
+
+
+def test_notifications_main_sends_marked_unenroll_reconciliation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_file = tmp_path / "env_unenroll_noop"
+    monkeypatch.setenv("GITHUB_ENV", str(env_file))
+    monkeypatch.setenv("ENROLL_RESULT", "noop")
+    monkeypatch.setenv("REGYBOX_OPERATION", "unenroll")
+    monkeypatch.setenv("NOTIFY_UNENROLL_NOOP", "true")
+    monkeypatch.setenv("CLASS_TYPE", "WOD")
+    monkeypatch.setenv("CLASS_DATE", "2026-03-04")
+    monkeypatch.setenv("CLASS_TIME", "06:30")
+
+    notifications_module.main()
+
+    env_text = env_file.read_text(encoding="utf-8")
+    assert "Regybox Auto-unenroll: already removed" in env_text
+    assert "SHOULD_SEND_EMAIL<<REGYBOX_SHOULD_SEND_EMAIL_EOF\ntrue" in env_text
 
 
 def test_read_kv_json_returns_empty_for_missing_value() -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -30,6 +30,11 @@ from regybox.notifications import (
 )
 
 FAKE_CREDENTIAL = "not-a-real-value"
+NOTIFICATION_CONTRACTS = json.loads(
+    (Path(__file__).parent / "fixtures" / "notification_contracts.json").read_text(
+        encoding="utf-8"
+    )
+)
 
 
 def test_extract_user_error_payload() -> None:
@@ -157,18 +162,27 @@ def test_build_email_content_unenroll_success() -> None:
 
 
 def test_build_email_content_unenroll_reconciliation() -> None:
+    contract = NOTIFICATION_CONTRACTS["reconciled_unenrollment"]
+
     subject, body = build_email_content(
         operation="unenroll",
         enroll_result="noop",
-        class_summary="WOD on 2026-03-04 at 06:30",
-        run_url="https://example.com/run",
+        class_summary=contract["class_summary"],
+        run_url="",
         log_text="",
     )
 
-    assert subject == "Regybox Auto-unenroll: already removed for WOD on 2026-03-04 at 06:30"
-    assert "The scheduler reconciled its previous enrollment record." in body
-    assert "You were already unenrolled, so no additional change was needed." in body
-    assert "Workflow run (optional): https://example.com/run" in body
+    assert subject == contract["subject"]
+    assert body == contract["body"]
+
+    _, linked_body = build_email_content(
+        operation="unenroll",
+        enroll_result="noop",
+        class_summary=contract["class_summary"],
+        run_url="https://example.com/run",
+        log_text="",
+    )
+    assert linked_body.endswith("Workflow run (optional): https://example.com/run")
 
 
 def test_build_email_content_unenroll_failure() -> None:

--- a/tests/test_regybox.py
+++ b/tests/test_regybox.py
@@ -706,6 +706,27 @@ def test_main_calls_check_cal_when_check_calendar_true() -> None:
     assert call_kw["class_type"] == "WOD Rato"
 
 
+def test_main_skips_calendar_check_for_unenroll() -> None:
+    mock_class: MagicMock = MagicMock()
+    mock_class.name = "WOD Rato"
+    mock_class.user_is_enrolled = False
+    with (
+        patch("regybox.regybox.check_cal") as mock_check_cal,
+        patch("regybox.regybox.get_classes", return_value=[mock_class]),
+        patch("regybox.regybox.pick_class", return_value=mock_class),
+    ):
+        result = main(
+            class_date="2026-03-10",
+            class_time="06:30",
+            class_type="WOD Rato",
+            check_calendar=True,
+            operation_options=OperationOptions(operation="unenroll"),
+        )
+
+    mock_check_cal.assert_not_called()
+    assert result == OperationResult(operation="unenroll", status="noop", class_type="WOD Rato")
+
+
 def test_main_calls_check_cal_with_explicit_event_name() -> None:
     mock_class: MagicMock = MagicMock()
     mock_class.is_open = True


### PR DESCRIPTION
- email users when automated stale enrollments are already removed
- keep calendar validation from blocking unenrollment cleanup
- strengthen repeated exclusion and workflow metadata regressions